### PR TITLE
Don't modify global random state when validating on train data

### DIFF
--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -7,9 +7,8 @@ from tlc_ultralytics.settings import Settings
 from tlc_ultralytics.constants import TLC_COLORSTR, DEFAULT_TRAIN_RUN_DESCRIPTION
 from tlc_ultralytics.utils import reduce_embeddings
 from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK
-from ultralytics.utils.torch_utils import strip_optimizer
 from ultralytics.utils.metrics import smooth
-from tlc_ultralytics.engine.utils import _complete_label_column_name
+from tlc_ultralytics.engine.utils import _complete_label_column_name, _restore_random_state
 
 
 class TLCTrainerMixin(BaseTrainer):
@@ -130,7 +129,8 @@ class TLCTrainerMixin(BaseTrainer):
             and not self._settings.collection_val_only
             and self.epoch + 1 in self._metrics_collection_epochs
         ):
-            self.train_validator(trainer=self)
+            with _restore_random_state():
+                self.train_validator(trainer=self)
 
         # Validate on the validation/test set like usual
         return super().validate()
@@ -138,24 +138,20 @@ class TLCTrainerMixin(BaseTrainer):
     def final_eval(self):
         # Set epoch on validator - required when final validation is called without prior mc during training
         if not self._settings.collection_val_only and not self._settings.collection_disable:
-            self.train_validator._final_validation = True
-            self.train_validator._epoch = self.epoch
-            self.train_validator.data = self.data
+            with _restore_random_state():
+                self.train_validator._final_validation = True
+                self.train_validator._epoch = self.epoch
+                self.train_validator.data = self.data
 
         self.validator._final_validation = True
 
-        for f in self.last, self.best:
-            if f.exists():
-                strip_optimizer(f)  # strip optimizers
-                if f is self.best:
-                    LOGGER.info(f"\nValidating {f}...")
-                    if not self._settings.collection_val_only and not self._settings.collection_disable:
-                        self.train_validator(model=f)
-                    self.validator.args.plots = self.args.plots
-                    self.metrics = self.validator(model=f)  # Only a dict! strange..?
-                    self.metrics.pop("fitness", None)
-                    self._save_confidence_metrics()
-                    self.run_callbacks("on_fit_epoch_end")
+        super().final_eval()
+
+        if self.best.exists():
+            self._save_confidence_metrics()
+
+            with _restore_random_state():
+                self.train_validator(model=self.best)
 
         if RANK in {-1, 0}:
             if self._settings.image_embeddings_dim > 0:

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -136,14 +136,9 @@ class TLCTrainerMixin(BaseTrainer):
         return super().validate()
 
     def final_eval(self):
-        """Perform normal final validation with metrics collection on the val set, then do extra metrics collection on
-        the train set.
+        """Perform normal final validation with metrics collection on the val set, after first doing metrics collection
+        on the train set.
         """
-        self.validator._final_validation = True
-
-        super().final_eval()
-        self._save_confidence_metrics()
-
         if not self._settings.collection_val_only and not self._settings.collection_disable:
             if self.best.exists():
                 with _restore_random_state():
@@ -151,6 +146,10 @@ class TLCTrainerMixin(BaseTrainer):
                     self.train_validator._epoch = self.epoch
                     self.train_validator.data = self.data
                     self.train_validator(model=self.best)
+
+        self.validator._final_validation = True
+        super().final_eval()
+        self._save_confidence_metrics()
 
         if RANK in {-1, 0}:
             if self._settings.image_embeddings_dim > 0:

--- a/src/tlc_ultralytics/engine/utils.py
+++ b/src/tlc_ultralytics/engine/utils.py
@@ -1,3 +1,7 @@
+import contextlib
+import random
+
+
 def _complete_label_column_name(label_column_name: str, default_label_column_name: str) -> str:
     """Create a complete label column name from a potentially partial one.
 
@@ -19,3 +23,11 @@ def _complete_label_column_name(label_column_name: str, default_label_column_nam
             parts.append(default_part)
 
     return ".".join(parts)
+
+
+@contextlib.contextmanager
+def _restore_random_state():
+    """Context manager to ensure the global random state is unchanged by the wrapped code."""
+    state = random.getstate()
+    yield
+    random.setstate(state)

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -25,7 +25,6 @@ from tlc_ultralytics.constants import (
 from tlc_ultralytics.engine.utils import _complete_label_column_name
 from tlc_ultralytics.settings import Settings
 from tlc_ultralytics.utils import image_embeddings_schema, training_phase_schema
-# from tlc_ultralytics.overrides import set_dataset_checking_bypass, reset_dataset_checking
 
 
 def execute_when_collecting(method):

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -88,10 +88,10 @@ def test_training(task) -> None:
     # End-to-end test of training for detection and segmentation
     overrides = {
         "data": TASK2DATASET[task],
-        "epochs": 1,
+        "epochs": 2,
         "batch": 4,
         "device": "cpu",
-        "save": False,
+        "save": True,
         "plots": False,
         "seed": 3 + ord("L") + ord("C"),
         "deterministic": True,
@@ -161,12 +161,13 @@ def test_training(task) -> None:
     assert 1 in metrics_df[TRAINING_PHASE], "Expected metrics from after training"
 
     # model.predict() should work and be the same as vanilla ultralytics
-    # assert all(model_ultralytics.predict(imgsz=320)[0].boxes.cls == model_3lc.predict(imgsz=320)[0].boxes.cls), (
-    #     "Predictions mismatch"
-    # )
+    assert all(model_ultralytics.predict(imgsz=320)[0].boxes.cls == model_3lc.predict(imgsz=320)[0].boxes.cls), (
+        "Predictions mismatch"
+    )
 
     per_class_metrics_tables = metrics_tables[PER_CLASS_METRICS_STREAM_NAME]
-    assert len(per_class_metrics_tables) == 4, "Expected 4 per-class metrics tables to be written"
+    # 6 = 2 epochs * 2 splits + 2 splits after training
+    assert len(per_class_metrics_tables) == 6, "Expected 6 per-class metrics tables to be written"
     per_class_metrics_df = pd.concat(
         [m.to_pandas() for m in per_class_metrics_tables],
         ignore_index=True,


### PR DESCRIPTION
Test training for two epochs with metrics collection after the first, to cover another case of extra calls to `random`. Keep and reset random state when doing extra "3lc-ultralytics"-only validation passes.