### PR TITLE
Add instruction on how to install with `uv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop"
 > ⚠️ NOTE: If you are using `uv`, instead use
 >
 > ```bash
-> uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources`
+> uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources
 > ```
 
 ### Basic Training

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install the package and requirements into a virtual environment:
 pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop"
 ```
 
-> ❗ NOTE: If you are using `uv`, use `uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources` instead.
+> ⚠️ NOTE: If you are using `uv`, use `uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources` instead.
 
 ### Basic Training
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Install the package and requirements into a virtual environment:
 pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop"
 ```
 
-> ⚠️ NOTE: If you are using `uv`, use `uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources` instead.
+> ⚠️ NOTE: If you are using `uv`, instead use
+>
+> ```bash
+> uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources`
+> ```
 
 ### Basic Training
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Install the package and requirements into a virtual environment:
 pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop"
 ```
 
+> ❗ NOTE: If you are using `uv`, use `uv pip install "git+https://github.com/3lc-ai/3lc-ultralytics@develop" --no-sources` instead.
+
 ### Basic Training
 
 Import `YOLO` from `tlc_ultralytics` and start training with 3LC integration:


### PR DESCRIPTION
The current setup has a local source for `3lc`, which is unavailable for most users. `--no-sources` has to be used to instead use PyPI as the source for `3lc`. 