### PR TITLE
Patch check for newer versions to always return False

### DIFF
--- a/src/tlc_ultralytics/__init__.py
+++ b/src/tlc_ultralytics/__init__.py
@@ -12,6 +12,7 @@ from tlc_ultralytics.settings import Settings
 
 # Patch the check_pip_update_available function to avoid prompting for an update
 import ultralytics
+
 ultralytics.utils.checks.check_pip_update_available = check_pip_update_available
 
 __all__ = [

--- a/src/tlc_ultralytics/__init__.py
+++ b/src/tlc_ultralytics/__init__.py
@@ -1,11 +1,18 @@
+# ruff: noqa: I001, E402
+
 import random
 
 import sentry_sdk
 
 sentry_sdk.profiler.transaction_profiler.random = random.Random()
 
-from tlc_ultralytics.engine.model import TLCYOLO, YOLO  # noqa: E402
-from tlc_ultralytics.settings import Settings  # noqa: E402
+from tlc_ultralytics.engine.model import TLCYOLO, YOLO
+from tlc_ultralytics.overrides import check_pip_update_available
+from tlc_ultralytics.settings import Settings
+
+# Patch the check_pip_update_available function to avoid prompting for an update
+import ultralytics
+ultralytics.utils.checks.check_pip_update_available = check_pip_update_available
 
 __all__ = [
     "TLCYOLO",

--- a/src/tlc_ultralytics/__init__.py
+++ b/src/tlc_ultralytics/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: I001, E402
+# ruff: noqa: E402
 
 import random
 
@@ -7,13 +7,7 @@ import sentry_sdk
 sentry_sdk.profiler.transaction_profiler.random = random.Random()
 
 from tlc_ultralytics.engine.model import TLCYOLO, YOLO
-from tlc_ultralytics.overrides import check_pip_update_available
 from tlc_ultralytics.settings import Settings
-
-# Patch the check_pip_update_available function to avoid prompting for an update
-import ultralytics
-
-ultralytics.utils.checks.check_pip_update_available = check_pip_update_available
 
 __all__ = [
     "TLCYOLO",

--- a/src/tlc_ultralytics/engine/model.py
+++ b/src/tlc_ultralytics/engine/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 import tlc
+import ultralytics
 from ultralytics.models import yolo
 from ultralytics.models.yolo.model import YOLO as YOLOBase
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel
@@ -14,6 +15,7 @@ from tlc_ultralytics.classify import (
 )
 from tlc_ultralytics.constants import DEFAULT_COLLECT_RUN_DESCRIPTION
 from tlc_ultralytics.detect import TLCDetectionTrainer, TLCDetectionValidator
+from tlc_ultralytics.overrides import check_pip_update_available
 from tlc_ultralytics.segment import (
     TLCSegmentationTrainer,
     TLCSegmentationValidator,
@@ -31,6 +33,19 @@ class YOLO(YOLOBase):
         check_tlc_version()
 
         super().__init__(*args, **kwargs)
+
+    def train(self, *args, **kwargs):
+        """Train the model."""
+        # Patch the check_pip_update_available function to avoid prompting for an update
+        ultralytics_check_pip_update_available = ultralytics.utils.checks.check_pip_update_available
+        ultralytics.utils.checks.check_pip_update_available = check_pip_update_available
+
+        output = super().train(*args, **kwargs)
+
+        # Restore the original function
+        ultralytics.utils.checks.check_pip_update_available = ultralytics_check_pip_update_available
+
+        return output
 
     @property
     def task_map(self):

--- a/src/tlc_ultralytics/engine/model.py
+++ b/src/tlc_ultralytics/engine/model.py
@@ -15,7 +15,6 @@ from tlc_ultralytics.classify import (
 )
 from tlc_ultralytics.constants import DEFAULT_COLLECT_RUN_DESCRIPTION
 from tlc_ultralytics.detect import TLCDetectionTrainer, TLCDetectionValidator
-from tlc_ultralytics.overrides import check_pip_update_available
 from tlc_ultralytics.segment import (
     TLCSegmentationTrainer,
     TLCSegmentationValidator,
@@ -36,9 +35,13 @@ class YOLO(YOLOBase):
 
     def train(self, *args, **kwargs):
         """Train the model."""
+
         # Patch the check_pip_update_available function to avoid prompting for an update
+        def check_pip_update_avaliable_return_false():
+            return False
+
         ultralytics_check_pip_update_available = ultralytics.utils.checks.check_pip_update_available
-        ultralytics.utils.checks.check_pip_update_available = check_pip_update_available
+        ultralytics.utils.checks.check_pip_update_available = check_pip_update_avaliable_return_false
 
         output = super().train(*args, **kwargs)
 

--- a/src/tlc_ultralytics/overrides.py
+++ b/src/tlc_ultralytics/overrides.py
@@ -40,3 +40,10 @@ def build_dataloader(*args, **kwargs):
     ultralytics.data.build.InfiniteDataLoader = InfiniteDataLoader
 
     return dataloader
+
+
+def check_pip_update_available() -> bool:
+    """Check whether a new version is available. This override always returns False such that the user is not prompted
+    to update.
+    """
+    return False

--- a/src/tlc_ultralytics/overrides.py
+++ b/src/tlc_ultralytics/overrides.py
@@ -40,10 +40,3 @@ def build_dataloader(*args, **kwargs):
     ultralytics.data.build.InfiniteDataLoader = InfiniteDataLoader
 
     return dataloader
-
-
-def check_pip_update_available() -> bool:
-    """Check whether a new version is available. This override always returns False such that the user is not prompted
-    to update.
-    """
-    return False

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -163,11 +163,11 @@ def test_training(task) -> None:
     ultralytics_messages = [record.message for record in ultralytics_records]
     tlc_messages = [record.message for record in tlc_records]
 
-    # Check that there is a message with "New <url> available" and "Update with " in ultralytics outputs
+    # Check that there is a message prompting an update
     msg = "Update with 'pip install -U ultralytics'"
     assert any(msg in message for message in ultralytics_messages), f"Did not find {msg} in ultralytics logs"
 
-    # Check that there is no message with "New <url> available" and "Update with " in 3LC outputs
+    # Check that there are no messages prompting an update
     assert not any(msg in message for message in tlc_messages), (
         f"Found {msg} in 3LC logs, which should be patched to not happen"
     )

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from collections import defaultdict
@@ -82,9 +83,35 @@ def get_metrics_tables_from_run(run: tlc.Run) -> dict[str, list[tlc.Table]]:
     return metrics_tables
 
 
+class CapturingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.log_records = []
+        self.log_messages = []
+
+    def emit(self, record):
+        self.log_records.append(record)
+        self.log_messages.append(self.format(record))
+
+
 @pytest.mark.parametrize("task", ["detect", "segment"])
 def test_training(task) -> None:
     # End-to-end test of training for detection and segmentation
+
+    # Capture ultralytics logger output specifically
+    from ultralytics.utils import LOGGER
+
+    ultralytics_logger = LOGGER
+
+    # Create handlers for both ultralytics and 3LC runs
+    ultralytics_handler = CapturingHandler()
+    ultralytics_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(message)s")
+    ultralytics_handler.setFormatter(formatter)
+
+    # Add handler to ultralytics logger
+    ultralytics_logger.addHandler(ultralytics_handler)
+
     overrides = {
         "data": TASK2DATASET[task],
         "epochs": 2,
@@ -105,13 +132,45 @@ def test_training(task) -> None:
         run_description=f"Test {task} training",
     )
 
+    # Run ultralytics training and capture logs
     model_ultralytics = YOLO(TASK2MODEL[task])
     results_ultralytics = model_ultralytics.train(**overrides)
 
+    # Clear the handler to separate ultralytics and 3LC logs
+    ultralytics_logger.removeHandler(ultralytics_handler)
+
+    # Create handler for 3LC run
+    tlc_handler = CapturingHandler()
+    tlc_handler.setLevel(logging.INFO)
+    tlc_handler.setFormatter(formatter)
+
+    # Add handler to ultralytics logger for 3LC run
+    ultralytics_logger.addHandler(tlc_handler)
+
+    # Run 3LC training and capture logs
     model_3lc = TLCYOLO(TASK2MODEL[task])
     results_3lc = model_3lc.train(**overrides, settings=settings)
 
     assert results_3lc, "Detection training failed"
+
+    # Clean up handlers
+    ultralytics_logger.removeHandler(tlc_handler)
+
+    # Get log records from both runs
+    ultralytics_records = ultralytics_handler.log_records
+    tlc_records = tlc_handler.log_records
+
+    ultralytics_messages = [record.message for record in ultralytics_records]
+    tlc_messages = [record.message for record in tlc_records]
+
+    # Check that there is a message with "New <url> available" and "Update with " in ultralytics outputs
+    msg = "Update with 'pip install -U ultralytics'"
+    assert any(msg in message for message in ultralytics_messages), f"Did not find {msg} in ultralytics logs"
+
+    # Check that there is no message with "New <url> available" and "Update with " in 3LC outputs
+    assert not any(msg in message for message in tlc_messages), (
+        f"Found {msg} in 3LC logs, which should be patched to not happen"
+    )
 
     # Compare 3LC integration with ultralytics results
     # Segmentation results will be slightly different due to the 3lc mask storage format and conversion


### PR DESCRIPTION
Ultralytics will prompt users to install the latest version, even though this sits outside of the range supported by `tlc_ultralytics`. This PR patches the function that checks for whether a new version is available to always return `False`.