### PR TITLE
Warn instead of raising when 3lc or ultralytics outside required version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 ## [Unreleased]
 
+# Changed
+
+- Modify the check for compatible versions of `3lc` and `ultralytics` to warn instead of raising ([#33](https://github.com/3lc-ai/3lc-ultralytics/pull/33)).
+
 ## [0.1.3] - 2025-08-28
 
 ### Added

--- a/src/tlc_ultralytics/utils/check_requirements.py
+++ b/src/tlc_ultralytics/utils/check_requirements.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 
 from packaging.specifiers import SpecifierSet
+from ultralytics.utils import LOGGER
 
 from tlc_ultralytics.constants import REQUIREMENTS_TO_CHECK
 
@@ -19,7 +20,11 @@ def check_requirements(requirements_to_check: list[tuple[str, str]] = REQUIREMEN
         try:
             importlib.import_module(import_name)
         except ImportError:
-            raise ImportError(f"Failed to import '{import_name}', please install it.") from None
+            msg = (
+                f"Failed to import '{import_name}', which is a required dependency of 3lc-ultralytics. "
+                f"Please install it with `pip install {package_name}` or equivalent."
+            )
+            raise ImportError(msg) from None
 
         # Check the version of the package and match it against the version set specifier
         installed_version = importlib.metadata.version(package_name)
@@ -30,10 +35,11 @@ def check_requirements(requirements_to_check: list[tuple[str, str]] = REQUIREMEN
         )
 
         if required_version_specifier is None:
-            raise ValueError(f"No version specifier found for '{package_name}'.")
+            LOGGER.warning(f"No version specifier found for '{package_name}', skipping version check.")
 
         if installed_version not in SpecifierSet(required_version_specifier):
-            raise ImportError(
+            LOGGER.warning(
                 f"The installed version of '{package_name}' ({installed_version}) is outside the required version "
-                f"range {required_version_specifier}. Please install a compatible version."
+                f"range {required_version_specifier}. This may cause compatibility issues, please use a compatible "
+                "version if issues are encountered."
             )

--- a/src/tlc_ultralytics/utils/check_requirements.py
+++ b/src/tlc_ultralytics/utils/check_requirements.py
@@ -9,10 +9,11 @@ from tlc_ultralytics.constants import REQUIREMENTS_TO_CHECK
 
 
 def check_requirements(requirements_to_check: list[tuple[str, str]] = REQUIREMENTS_TO_CHECK) -> None:
-    """Check the versions of the required packages matches the version specifiers in pyproject.toml.
+    """Check the versions of the required packages are installed, and warn if the versions are not 
+    known to be compatible.
 
     :param requirements_to_check: List of tuples of (package name, import name) of packages to check.
-    :raises ImportError: If the requirements are not met.
+    :raises ImportError: If the requirements are not installed.
     """
     tlc_ultralytics_requirements = importlib.metadata.metadata("3lc-ultralytics").json["requires_dist"]
 
@@ -35,7 +36,7 @@ def check_requirements(requirements_to_check: list[tuple[str, str]] = REQUIREMEN
         )
 
         if required_version_specifier is None:
-            LOGGER.warning(f"No version specifier found for '{package_name}', skipping version check.")
+            LOGGER.info(f"No version specifier found for '{package_name}', skipping version check.")
 
         if installed_version not in SpecifierSet(required_version_specifier):
             LOGGER.warning(

--- a/src/tlc_ultralytics/utils/check_requirements.py
+++ b/src/tlc_ultralytics/utils/check_requirements.py
@@ -9,7 +9,7 @@ from tlc_ultralytics.constants import REQUIREMENTS_TO_CHECK
 
 
 def check_requirements(requirements_to_check: list[tuple[str, str]] = REQUIREMENTS_TO_CHECK) -> None:
-    """Check the versions of the required packages are installed, and warn if the versions are not 
+    """Check the versions of the required packages are installed, and warn if the versions are not
     known to be compatible.
 
     :param requirements_to_check: List of tuples of (package name, import name) of packages to check.


### PR DESCRIPTION
Adds
```
WARNING ⚠️ The installed version of '3lc' (2.17) is outside the required version range >=2.13.1,!=2.16.1,<=2.16.2. This may cause compatibility issues, please use a compatible version if issues are encountered.
```
as the first piece of output if the version is unsupported instead of raising an error.

Quite visible and seems better than raising when a newer version might work.