### PR TITLE
Support DDP training from `tables`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,19 +158,13 @@ Note that `names` and `nc` are not needed since the `tlc.Table`s themselves cont
 
 ## Task-Specific Configuration
 
-### Classification
-
-For image classification, you can provide `image_column_name` and `label_column_name` when calling `model.train()`, `model.val()` and `model.collect()` if you are providing your own table which has different column names to those expected by 3LC.
-
 ### Object Detection
 
-In addition to tables created with `Table.from_yolo()` (which is called internally when you provide a YOLO dataset), it is also possible to use tables with the COCO format used in the 3LC Detectron2 integration. If you have created 3LC tables in the Detectron2 integration, you can also use this `tlc.Table` in this integration!
+In addition to tables created with `Table.from_yolo()` (which is called internally when you provide a YOLO dataset), it is also possible to use other 3LC `Table`s with bounding boxes, such as `tlc.Table.from_coco()`.
 
 ### Segmentation
 
 Working with instance segmentation in the 3LC integration is similar to object detection. If you are using `tlc.Table.from_yolo()` to create your tables, make sure to pass `task="segment"`, as the default is `"detect"`.
-
-For instance segmentation, you can provide `image_column_name` and `label_column_name` when calling `model.train()`, `model.val()` and `model.collect()` if you are providing your own table which has different column names to those expected by 3LC. Note that the `label_column_name` should be the path to the segmentation label field within the table schema, with the default being `"segmentations.instance_properties.label"` which points to the category labels for each segmentation instance.
 
 ### Unsupported Tasks
 
@@ -208,7 +202,7 @@ model.collect(
 
 See [examples/detect/collect.py](examples/detect/collect.py) for a complete metrics collection example.
 
-> WARNING ⚠️: When using `.collect()`, the model must be compatible with the provided `tlc.Table`.
+> WARNING ⚠️: When using `.collect()`, the model must be compatible with the provided `tlc.Table`(s).
 > For example, the categories (called `names` in Ultralytics) in the `tlc.Table`s must match those that the model was trained on.
 
 ## 3LC Settings
@@ -247,6 +241,10 @@ Use `exclude_zero_weight_training=True` (only applies to training) and `exclude_
 - **`collection_val_only=True`**: Disable metrics collection on the training set. This only applies to training.
 - **`collection_disable=True`**: Disable metrics collection entirely. This only applies to training. A run will still be created, and hyperparameters and aggregate metrics will be logged to 3LC.
 - **`collection_epoch_start` and `collection_epoch_interval`**: Define when to collect metrics during training. The start epoch is 1-based, i.e. 1 means after the first epoch. As an example, `collection_epoch_start=1` with `collection_epoch_interval=2` means metrics collection will occur after the first epoch and then every other epoch after that.
+
+### Column names
+
+When providing `tables` directly or through a 3LC YOLO YAML file which have non-default column names, set the `image_column_name` and `label_column_name` in the `Settings` object. While `image_column_name` needs to be the top-level column name of image column, the `label_column_name` can be either the top level column (such as `"bbs"` for detection) or a value path to the label inside the detection column (such as `"bbs.bb_list.label"` for detection).
 
 ## Dashboard Output
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ tables = {
     "train": my_train_table, 
     "val": my_val_table
 }
-model.train(tables=tables)
+model.train(tables=tables, ...)
 
 # Using table URLs
 tables = {
@@ -113,7 +113,7 @@ tables = {
 model.train(tables=tables, ...)
 ```
 
-When `tables` is provided, any value of `data` is ignored. In training, the table for the key `"train"` is used for training, and `"val"` or `"test"` for validation (val takes precedence).
+In training, when a dictionary of tables is passed to `tables`, the table for the key `"train"` is used for training, and `"val"` or `"test"` for validation (val takes precedence).
 
 </details>
 

--- a/src/tlc_ultralytics/classify/trainer.py
+++ b/src/tlc_ultralytics/classify/trainer.py
@@ -21,7 +21,7 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
     _default_image_column_name = IMAGE_COLUMN_NAME
     _default_label_column_name = CLASSIFY_LABEL_COLUMN_NAME
 
-    def _get_dataset(self):
+    def get_dataset(self):
         """Overrides the get_dataset method to get or create 3LC tables."""
         self.data = tlc_check_cls_dataset(
             self.args.data,

--- a/src/tlc_ultralytics/classify/trainer.py
+++ b/src/tlc_ultralytics/classify/trainer.py
@@ -26,8 +26,8 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
         self.data = tlc_check_cls_dataset(
             self.args.data,
             self._tables,
-            self._image_column_name,
-            self._label_column_name,
+            self._settings.image_column_name,
+            self._settings.label_column_name,
             project_name=self._settings.project_name,
             splits=("train", "val"),
         )
@@ -35,8 +35,8 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
             data_test = tlc_check_cls_dataset(
                 self.args.data,
                 self._tables,
-                self._image_column_name,
-                self._label_column_name,
+                self._settings.image_column_name,
+                self._settings.label_column_name,
                 project_name=self._settings.project_name,
                 splits=("test",),
             )
@@ -52,8 +52,8 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
             args=self.args,
             augment=mode == "train",
             prefix=mode,
-            image_column_name=self._image_column_name,
-            label_column_name=self._label_column_name,
+            image_column_name=self._settings.image_column_name,
+            label_column_name=self._settings.label_column_name,
             exclude_zero=exclude_zero,
             class_map=self.data["3lc_class_to_range"],
         )
@@ -66,8 +66,6 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
             self.save_dir,
             _callbacks=self.callbacks,
             run=self._run,
-            image_column_name=self._image_column_name,
-            label_column_name=self._label_column_name,
             settings=self._settings,
             training=True,
         )

--- a/src/tlc_ultralytics/classify/trainer.py
+++ b/src/tlc_ultralytics/classify/trainer.py
@@ -21,7 +21,7 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
     _default_image_column_name = IMAGE_COLUMN_NAME
     _default_label_column_name = CLASSIFY_LABEL_COLUMN_NAME
 
-    def get_dataset(self):
+    def _get_dataset(self):
         """Overrides the get_dataset method to get or create 3LC tables."""
         self.data = tlc_check_cls_dataset(
             self.args.data,

--- a/src/tlc_ultralytics/classify/validator.py
+++ b/src/tlc_ultralytics/classify/validator.py
@@ -28,8 +28,8 @@ class TLCClassificationValidator(TLCValidatorMixin, yolo.classify.Classification
             args=self.args,
             augment=False,
             prefix=self.args.split,
-            image_column_name=self._image_column_name,
-            label_column_name=self._label_column_name,
+            image_column_name=self._settings.image_column_name,
+            label_column_name=self._settings.label_column_name,
             exclude_zero=self._settings.exclude_zero_weight_collection,
             class_map=self.data["3lc_class_to_range"],
         )
@@ -81,7 +81,7 @@ class TLCClassificationValidator(TLCValidatorMixin, yolo.classify.Classification
             "top1_accuracy": (torch.argmax(preds, dim=1) == batch["cls"]).to(torch.float32),
         }
 
-        if len(self.dataloader.dataset.table.get_value_map(self._label_column_name)) > 5:
+        if len(self.dataloader.dataset.table.get_value_map(self._settings.label_column_name)) > 5:
             _, top5_pred = torch.topk(preds, 5, dim=1)
             labels_expanded = batch["cls"].view(-1, 1).expand_as(top5_pred)
             top5_correct = torch.any(top5_pred == labels_expanded, dim=1)

--- a/src/tlc_ultralytics/constants.py
+++ b/src/tlc_ultralytics/constants.py
@@ -30,8 +30,3 @@ REQUIREMENTS_TO_CHECK = [
     ("3lc", "tlc"),
     ("ultralytics", "ultralytics"),
 ]
-
-# Output files
-SETTINGS_FILE_NAME = "settings_3lc.yaml"
-TABLES_FILE_NAME = "tables_3lc.yaml"
-RUN_FILE_NAME = "run.json"

--- a/src/tlc_ultralytics/constants.py
+++ b/src/tlc_ultralytics/constants.py
@@ -30,3 +30,8 @@ REQUIREMENTS_TO_CHECK = [
     ("3lc", "tlc"),
     ("ultralytics", "ultralytics"),
 ]
+
+# Output files
+SETTINGS_FILE_NAME = "settings_3lc.yaml"
+TABLES_FILE_NAME = "tables_3lc.yaml"
+RUN_FILE_NAME = "run.json"

--- a/src/tlc_ultralytics/detect/trainer.py
+++ b/src/tlc_ultralytics/detect/trainer.py
@@ -30,8 +30,8 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
         self.data = tlc_check_det_dataset(
             self.args.data,
             self._tables,
-            self._image_column_name,
-            self._label_column_name,
+            self._settings.image_column_name,
+            self._settings.label_column_name,
             project_name=self._settings.project_name,
             splits=("train", "val"),
         )
@@ -41,8 +41,8 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
             data_test = tlc_check_det_dataset(
                 self.args.data,
                 self._tables,
-                self._image_column_name,
-                self._label_column_name,
+                self._settings.image_column_name,
+                self._settings.label_column_name,
                 project_name=self._settings.project_name,
                 splits=("test",),
             )
@@ -60,8 +60,8 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
             build_tlc_yolo_dataset,
             exclude_zero=exclude_zero,
             class_map=self.data["3lc_class_to_range"],
-            image_column_name=self._image_column_name,
-            label_column_name=self._label_column_name,
+            image_column_name=self._settings.image_column_name,
+            label_column_name=self._settings.label_column_name,
         )
 
         result = DetectionTrainer.build_dataset(self, *args, **kwargs)
@@ -80,8 +80,6 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
             save_dir=self.save_dir,
             args=self.args,
             run=self._run,
-            image_column_name=self._image_column_name,
-            label_column_name=self._label_column_name,
             settings=self._settings,
             training=True,
         )

--- a/src/tlc_ultralytics/detect/trainer.py
+++ b/src/tlc_ultralytics/detect/trainer.py
@@ -25,7 +25,7 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
     _default_image_column_name = IMAGE_COLUMN_NAME
     _default_label_column_name = DETECTION_LABEL_COLUMN_NAME
 
-    def _get_dataset(self):
+    def get_dataset(self):
         # Parse yaml and create tables
         self.data = tlc_check_det_dataset(
             self.args.data,

--- a/src/tlc_ultralytics/detect/trainer.py
+++ b/src/tlc_ultralytics/detect/trainer.py
@@ -25,7 +25,7 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
     _default_image_column_name = IMAGE_COLUMN_NAME
     _default_label_column_name = DETECTION_LABEL_COLUMN_NAME
 
-    def get_dataset(self):
+    def _get_dataset(self):
         # Parse yaml and create tables
         self.data = tlc_check_det_dataset(
             self.args.data,

--- a/src/tlc_ultralytics/detect/validator.py
+++ b/src/tlc_ultralytics/detect/validator.py
@@ -40,8 +40,8 @@ class TLCDetectionValidator(TLCValidatorMixin, DetectionValidator):
             exclude_zero=self._settings.exclude_zero_weight_collection,
             class_map=self.data["3lc_class_to_range"],
             split=self.args.split,
-            image_column_name=self._image_column_name,
-            label_column_name=self._label_column_name,
+            image_column_name=self._settings.image_column_name,
+            label_column_name=self._settings.label_column_name,
         )
 
     def postprocess(self, preds):

--- a/src/tlc_ultralytics/engine/model.py
+++ b/src/tlc_ultralytics/engine/model.py
@@ -99,8 +99,6 @@ class YOLO(YOLOBase):
         if settings is None:
             settings = Settings()
 
-        settings.verify(training=False)
-
         if not settings.run_description:
             settings.run_description = DEFAULT_COLLECT_RUN_DESCRIPTION
 

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import tlc
+import yaml
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK
 from ultralytics.utils.metrics import smooth
@@ -22,6 +23,37 @@ class TLCTrainerMixin(BaseTrainer):
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         LOGGER.info("Using 3LC Trainer 🌟")
         self._settings = overrides.pop("settings", Settings())
+
+        # Override settings with image_column_name and label_column_name, both deprecated
+        for column_name in ["image_column_name", "label_column_name"]:
+            if column_name in overrides:
+                msg = (
+                    f"`{column_name}` is deprecated. Provide `{column_name}` to a `Settings` object instead."
+                )
+                LOGGER.warning(f"{TLC_COLORSTR}{msg}")
+
+                value = overrides.pop(column_name)
+
+                if getattr(self._settings, column_name) is not None:
+                    msg = (
+                        f"`{column_name}` is both set in the `Settings` object and provided directly. Using the one "
+                        "from the `Settings` object."
+                    )
+                    LOGGER.warning(f"{TLC_COLORSTR}{msg}")
+
+                else:
+                    setattr(self._settings, column_name, value)
+
+        self._label_column_name = _complete_label_column_name(
+            self._settings.label_column_name,
+            self._default_label_column_name,
+        )
+
+        if self._settings.image_column_name is None:
+            self._settings.image_column_name = self._default_image_column_name
+
+        self._image_column_name = self._settings.image_column_name
+
         self._settings.verify(training=True)
 
         assert "data" in overrides or "tables" in overrides, (
@@ -35,14 +67,28 @@ class TLCTrainerMixin(BaseTrainer):
             )
             raise ValueError(msg)
 
-        self._tables = overrides.pop("tables", None)
+        tables = overrides.pop("tables", None)
 
-        # Column names
-        self._image_column_name = overrides.pop("image_column_name", self._default_image_column_name)
-        self._label_column_name = overrides.pop("label_column_name", self._default_label_column_name)
-        self._label_column_name = _complete_label_column_name(self._label_column_name, self._default_label_column_name)
+        if tables:
+            self._tables = {}
+            for k, v in tables.items():
+                if isinstance(v, tlc.Table):
+                    self._tables[k] = v.url.to_str()
+                elif isinstance(v, (str, Path, tlc.Url)):
+                    self._tables[k] = tlc.Url(v).to_str()
+                else:
+                    raise ValueError(f"Invalid type {type(v)} for split {k} provided through `tables`.")
+        else:
+            self._tables = None
 
         super().__init__(cfg, overrides, _callbacks)
+
+        # Handle case where DDP training is used - make settings available to all processes
+        settings_yaml_file_path = self._3lc_run_dir / "settings_3lc.yaml"
+        if RANK in {-1, 0}:
+            self._settings.to_yaml(settings_yaml_file_path)
+        else:
+            self._settings = Settings.from_yaml(settings_yaml_file_path)
 
         self._train_validator = None
         self._train_equals_val_result = None
@@ -109,6 +155,27 @@ class TLCTrainerMixin(BaseTrainer):
         LOGGER.info(f"{TLC_COLORSTR}{message}")
 
     def get_dataset(self):
+        tables_yaml_file_path = (self._3lc_run_dir / "tables_3lc.yaml").absolute()
+        self.args.data = f"3LC://{tables_yaml_file_path.as_posix()}"
+
+        # Write table urls to a 3LC YAML file in the run directory
+        if RANK == -1 and self._tables:
+            tables_yaml_file_path.write_text(yaml.safe_dump(self._tables))
+
+        return self._get_dataset()
+
+    @property
+    def _3lc_run_dir(self) -> Path:
+        if not hasattr(self, "save_dir"):
+            raise ValueError("save_dir is not set")
+
+        run_dir = Path(self.save_dir.parent / (self.save_dir.name + "_3lc"))
+
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        return run_dir
+
+    def _get_dataset(self):
         raise NotImplementedError("Subclasses must implement this method.")
 
     def build_dataset(self, table, mode="train", batch=None):

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -28,12 +28,12 @@ class TLCTrainerMixin(BaseTrainer):
         LOGGER.info("Using 3LC Trainer 🌟")
         self._settings = overrides.pop("settings", Settings())
 
-        self.settings.image_column_name = _handle_deprecated_column_name(
+        self._settings.image_column_name = _handle_deprecated_column_name(
             overrides.pop("image_column_name", None),
             self._settings.image_column_name,
             self._default_image_column_name,
         )
-        self.settings.label_column_name = _handle_deprecated_column_name(
+        self._settings.label_column_name = _handle_deprecated_column_name(
             overrides.pop("label_column_name", None),
             self._settings.label_column_name,
             self._default_label_column_name,
@@ -57,19 +57,7 @@ class TLCTrainerMixin(BaseTrainer):
             )
             raise ValueError(msg)
 
-        tables = overrides.pop("tables", None)
-
-        if tables:
-            self._tables = {}
-            for k, v in tables.items():
-                if isinstance(v, tlc.Table):
-                    self._tables[k] = v.url.to_str()
-                elif isinstance(v, (str, Path, tlc.Url)):
-                    self._tables[k] = tlc.Url(v).to_str()
-                else:
-                    raise ValueError(f"Invalid type {type(v)} for split {k} provided through `tables`.")
-        else:
-            self._tables = None
+        self._handle_tables_argument(overrides.pop("tables", None))
 
         super().__init__(cfg, overrides, _callbacks)
 
@@ -104,6 +92,20 @@ class TLCTrainerMixin(BaseTrainer):
             self._log_3lc_parameters()
             self._run.set_status_running()
             self._print_metrics_collection_epochs()
+
+    def _handle_tables_argument(self, tables: dict[str, tlc.Table | str | Path | tlc.Url] | None):
+        """Handle the tables argument."""
+        if tables:
+            self._tables = {}
+            for k, v in tables.items():
+                if isinstance(v, tlc.Table):
+                    self._tables[k] = v.url.to_str()
+                elif isinstance(v, (str, Path, tlc.Url)):
+                    self._tables[k] = tlc.Url(v).to_str()
+                else:
+                    raise ValueError(f"Invalid type {type(v)} for split {k} provided through `tables`.")
+        else:
+            self._tables = None
 
     def _log_3lc_parameters(self):
         """Log various data as parameters to the tlc.Run."""

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -66,9 +66,9 @@ class TLCTrainerMixin(BaseTrainer):
 
         self._train_validator = None
         self._train_equals_val_result = None
+        self._metrics_collection_epochs = set(self._settings.get_metrics_collection_epochs(self.epochs))
 
         if RANK == -1:
-            self._metrics_collection_epochs = set(self._settings.get_metrics_collection_epochs(self.epochs))
 
             # Create a 3LC run
             description = (
@@ -88,10 +88,17 @@ class TLCTrainerMixin(BaseTrainer):
                 f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}."
             )
 
+            (self._3lc_run_dir / "run.txt").write_text(self._run.url.to_str())
+
             # Log parameters to 3LC
             self._log_3lc_parameters()
             self._run.set_status_running()
             self._print_metrics_collection_epochs()
+
+        else:
+            run_url = (self._3lc_run_dir / "run.txt").read_text()
+            LOGGER.info(f"{TLC_COLORSTR}DDP Rank {RANK}: Using run from {run_url}")
+            self._run = tlc.Run.from_url(run_url)
 
     def _handle_tables_argument(self, tables: dict[str, tlc.Table | str | Path | tlc.Url] | None):
         """Handle the tables argument."""
@@ -152,9 +159,9 @@ class TLCTrainerMixin(BaseTrainer):
 
         tables_yaml_file_path = (self._3lc_run_dir / "tables_3lc.yaml").absolute()
 
-        if RANK == -1:
-            YAML.save(tables_yaml_file_path.as_posix(), self._tables or {})
-        else:
+        # If tables is non-empty
+        if self._tables and RANK == -1:
+            YAML.save(tables_yaml_file_path.as_posix(), self._tables)
             self.args.data = f"3LC://{tables_yaml_file_path.as_posix()}"
 
         return self._get_dataset()

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
 import json
-import shutil
 from pathlib import Path
 
 import tlc
+import ultralytics
 from ultralytics.engine.trainer import BaseTrainer
-from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK, YAML
+from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK
 from ultralytics.utils.metrics import smooth
 
 from tlc_ultralytics.constants import (
     DEFAULT_TRAIN_RUN_DESCRIPTION,
-    RUN_FILE_NAME,
-    SETTINGS_FILE_NAME,
-    TABLES_FILE_NAME,
     TLC_COLORSTR,
 )
 from tlc_ultralytics.engine.utils import (
@@ -23,6 +20,7 @@ from tlc_ultralytics.engine.utils import (
 )
 from tlc_ultralytics.settings import Settings
 from tlc_ultralytics.utils import reduce_embeddings
+from tlc_ultralytics.utils.generate_ddp import generate_ddp_command
 
 
 class TLCTrainerMixin(BaseTrainer):
@@ -33,103 +31,129 @@ class TLCTrainerMixin(BaseTrainer):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         LOGGER.info("Using 3LC Trainer 🌟")
-        self._settings = overrides.pop("settings", Settings())
 
-        self._settings.image_column_name = _handle_deprecated_column_name(
-            overrides.pop("image_column_name", None),
-            self._settings.image_column_name,
-            self._default_image_column_name,
-        )
-        self._settings.label_column_name = _handle_deprecated_column_name(
-            overrides.pop("label_column_name", None),
-            self._settings.label_column_name,
-            self._default_label_column_name,
-        )
+        if RANK == -1:
+            # Settings
+            self._settings = overrides.pop("settings", Settings())
 
-        self._settings.label_column_name = _complete_label_column_name(
-            self._settings.label_column_name,
-            self._default_label_column_name,
-        )
-
-        self._settings.verify(training=True)
-
-        assert "data" in overrides or "tables" in overrides, (
-            "You must provide either a data path or tables to train with 3LC."
-        )
-
-        if "data" in overrides and not isinstance(overrides["data"], (str, Path)):
-            msg = (
-                "`data` must be a string or pathlib.Path. "
-                "If you are using `tlc.Table` objects, provide `tables` instead."
+            self._settings.image_column_name = _handle_deprecated_column_name(
+                overrides.pop("image_column_name", None),
+                self._settings.image_column_name,
+                self._default_image_column_name,
             )
-            raise ValueError(msg)
+            self._settings.label_column_name = _handle_deprecated_column_name(
+                overrides.pop("label_column_name", None),
+                self._settings.label_column_name,
+                self._default_label_column_name,
+            )
 
-        self._handle_tables_argument(overrides.pop("tables", None))
+            self._settings.label_column_name = _complete_label_column_name(
+                self._settings.label_column_name,
+                self._default_label_column_name,
+            )
+
+            self._settings.verify(training=True)
+
+            # Tables / data
+            if "data" not in overrides and "tables" not in overrides:
+                msg = "You must provide either `data` or `tables` to train with 3LC."
+                raise ValueError(msg)
+
+            if "data" in overrides and not isinstance(overrides["data"], (str, Path)):
+                msg = "`data` must be a string. If you are passing tables directly, use the `tables` argument instead."
+                raise ValueError(msg)
+
+            # Ensure tables is a dictionary of URLs to the table urls
+            tables = overrides.pop("tables", None)
+            if tables:
+                self._tables = self._handle_tables_argument(tables)
+            else:
+                self._tables = None
+
+        else: # DDP worker nodes
+            try:
+                data = json.loads(overrides["data"])
+            except json.JSONDecodeError as e:
+                msg = f"RANK {RANK} expected `data` to be a JSON string with run url, settings and tables."
+                raise ValueError(msg) from e
+
+            for key in ("run_url", "settings"):
+                if key not in data:
+                    msg = f"RANK {RANK} expected `data` to contain a `{key}` key."
+                    raise ValueError(msg)
+
+            self._run = tlc.Run.from_url(data["run_url"])
+            self._settings = Settings(**data["settings"])
+            self._tables = data["tables"] if "tables" in data else None
+            self.args.data = data["data"] if "data" in data else ""
 
         super().__init__(cfg, overrides, _callbacks)
 
-        # Handle case where DDP training is used - make settings available to all processes
-        self._write_load_settings()
-
+        self._metrics_collection_epochs = set(self._settings.get_metrics_collection_epochs(self.epochs))
         self._train_validator = None
         self._train_equals_val_result = None
-        self._metrics_collection_epochs = set(self._settings.get_metrics_collection_epochs(self.epochs))
 
         if RANK == -1:
-            # Create a 3LC run
-            description = (
-                self._settings.run_description if self._settings.run_description else DEFAULT_TRAIN_RUN_DESCRIPTION
-            )
-
-            project_name = (
-                self._settings.project_name if self._settings.project_name else self.data["train"].project_name
-            )
-            self._run = tlc.init(
-                project_name=project_name,
-                description=description,
-                run_name=self._settings.run_name,
-            )
-            self._save_run_state()
-
-            LOGGER.info(
-                f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}."
-            )
-
-            # Log parameters to 3LC
+            self._create_run()
             self._log_3lc_parameters()
             self._run.set_status_running()
             self._print_metrics_collection_epochs()
 
-        else:
-            self._load_run_state()
-            LOGGER.info(f"{TLC_COLORSTR}DDP Rank {RANK}: Using run from {self._run.url.to_str()}")
+    def train(self):
+        """Override the train method to use custom generate_ddp_command function to serialize 3LC data in data argument.
+        """
+        ultralytics.engine.trainer.generate_ddp_command = generate_ddp_command
+        super().train()
+        ultralytics.engine.trainer.generate_ddp_command = ultralytics.utils.dist.generate_ddp_command
 
-    def _save_run_state(self):
-        """Save the run state to the 3LC run directory."""
-        run_state_file_path = self._3lc_run_dir / RUN_FILE_NAME
-        with open(run_state_file_path, "w") as f:
-            json.dump({"run_url": self._run.url.to_str()}, f)
+    def _serialize_state(self) -> str:
+        """Serialize the run url, settings and tables to a JSON string.
 
-    def _load_run_state(self):
-        """Load the run state from the 3LC run directory."""
-        run_state_file_path = self._3lc_run_dir / RUN_FILE_NAME
-        with open(run_state_file_path) as f:
-            run_state = json.load(f)
-        self._run = tlc.Run.from_url(run_state["run_url"])
+        :returns: A JSON string with the run url, settings and table URLs.
+        """
+        return json.dumps(
+            {
+                "run_url": self._run.url.to_str(),
+                "settings": self._settings.to_dict(),
+                "data": self.args.data if not self._tables else "",
+                "tables": self._tables if self._tables else None,
+            }
+        )
 
-    def _handle_tables_argument(self, tables: dict[str, tlc.Table | str | Path | tlc.Url] | None):
-        """Handle the tables argument."""
-        if tables:
-            self._tables = {}
-            for k, v in tables.items():
-                if isinstance(v, tlc.Table):
-                    self._tables[k] = v.url.to_str()
-                elif isinstance(v, (str, Path, tlc.Url)):
-                    self._tables[k] = tlc.Url(v).to_str()
-                else:
-                    raise ValueError(f"Invalid type {type(v)} for split {k} provided through `tables`.")
-        else:
-            self._tables = None
+    def _create_run(self) -> None:
+        """Create a run."""
+        # Create a 3LC run
+        description = (
+            self._settings.run_description if self._settings.run_description else DEFAULT_TRAIN_RUN_DESCRIPTION
+        )
+
+        project_name = (
+            self._settings.project_name if self._settings.project_name else self.data["train"].project_name
+        )
+        self._run = tlc.init(
+            project_name=project_name,
+            description=description,
+            run_name=self._settings.run_name,
+        )
+
+        LOGGER.info(
+            f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}."
+        )
+
+    @staticmethod
+    def _handle_tables_argument(tables: dict[str, tlc.Table | str | Path | tlc.Url]) -> dict[str, str]:
+        """Handle the tables argument and return it as a dictionary of URLs (as strings) to the Tables."""
+        table_urls = {}
+
+        for k, v in tables.items():
+            if isinstance(v, tlc.Table):
+                table_urls[k] = v.url.to_str()
+            elif isinstance(v, (str, Path, tlc.Url)):
+                table_urls[k] = tlc.Url(v).to_str()
+            else:
+                raise ValueError(f"Invalid type {type(v)} for split {k} of tables provided directly.")
+
+        return table_urls
 
     def _log_3lc_parameters(self):
         """Log various data as parameters to the tlc.Run."""
@@ -167,58 +191,6 @@ class TLCTrainerMixin(BaseTrainer):
         LOGGER.info(f"{TLC_COLORSTR}{message}")
 
     def get_dataset(self):
-        """Override get_dataset to write Table Urls to a 3LC YAML file in the run directory, and set the data
-        argument to the path to this YAML file to make it available to DDP processes.
-
-        It is implemented here because it requires access to the run directory, which is set in the parent __init__,
-        and before datasets are created.
-        """
-
-        tables_yaml_file_path = (self._3lc_run_dir / TABLES_FILE_NAME).absolute()
-
-        # If tables is non-empty
-        if self._tables and RANK == -1:
-            YAML.save(tables_yaml_file_path.as_posix(), self._tables)
-            self.args.data = f"3LC://{tables_yaml_file_path.as_posix()}"
-
-        return self._get_dataset()
-
-    @property
-    def _3lc_run_dir(self) -> Path:
-        if not hasattr(self, "save_dir"):
-            raise ValueError("save_dir is not set")
-
-        run_dir = Path(self.save_dir.parent / (self.save_dir.name + "_3lc"))
-
-        run_dir.mkdir(parents=True, exist_ok=True)
-
-        return run_dir
-
-    def _move_3lc_run_dir(self):
-        """Move the 3LC specific run artifacts to the Ultralytics run directory."""
-        source_dir = self._3lc_run_dir
-        target_dir = Path(self.save_dir)
-
-        for file in source_dir.glob("*"):
-            shutil.move(file, target_dir / file.name)
-
-        # Verify source dir is empty
-        assert not list(source_dir.glob("*")), "Source directory is not empty"
-        source_dir.rmdir()
-
-    def _write_load_settings(self):
-        """Make settings available to all processes through the run directory.
-
-        For the main node, the settings are written to the temporary 3lc run directory.
-        For launched DDP processes, the settings are loaded from the temporary 3lc run directory.
-        """
-        settings_yaml_file_path = self._3lc_run_dir / SETTINGS_FILE_NAME
-        if RANK == -1:
-            self._settings.to_yaml(settings_yaml_file_path)
-        else:
-            self._settings = Settings.from_yaml(settings_yaml_file_path)
-
-    def _get_dataset(self):
         raise NotImplementedError("Subclasses must implement this method.")
 
     def build_dataset(self, table, mode="train", batch=None):
@@ -298,7 +270,6 @@ class TLCTrainerMixin(BaseTrainer):
                     foreign_table_url=foreign_table_url,
                     reducer_args=self._settings.image_embeddings_reducer_args,
                 )
-            self._move_3lc_run_dir()
             self._run.set_status_completed()
 
     def _save_confidence_metrics(self):

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -69,7 +69,6 @@ class TLCTrainerMixin(BaseTrainer):
         self._metrics_collection_epochs = set(self._settings.get_metrics_collection_epochs(self.epochs))
 
         if RANK == -1:
-
             # Create a 3LC run
             description = (
                 self._settings.run_description if self._settings.run_description else DEFAULT_TRAIN_RUN_DESCRIPTION

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -8,7 +9,13 @@ from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK, YAML
 from ultralytics.utils.metrics import smooth
 
-from tlc_ultralytics.constants import DEFAULT_TRAIN_RUN_DESCRIPTION, TLC_COLORSTR
+from tlc_ultralytics.constants import (
+    DEFAULT_TRAIN_RUN_DESCRIPTION,
+    RUN_FILE_NAME,
+    SETTINGS_FILE_NAME,
+    TABLES_FILE_NAME,
+    TLC_COLORSTR,
+)
 from tlc_ultralytics.engine.utils import (
     _complete_label_column_name,
     _handle_deprecated_column_name,
@@ -82,12 +89,11 @@ class TLCTrainerMixin(BaseTrainer):
                 description=description,
                 run_name=self._settings.run_name,
             )
+            self._save_run_state()
 
             LOGGER.info(
                 f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}."
             )
-
-            (self._3lc_run_dir / "run.txt").write_text(self._run.url.to_str())
 
             # Log parameters to 3LC
             self._log_3lc_parameters()
@@ -95,9 +101,21 @@ class TLCTrainerMixin(BaseTrainer):
             self._print_metrics_collection_epochs()
 
         else:
-            run_url = (self._3lc_run_dir / "run.txt").read_text()
-            LOGGER.info(f"{TLC_COLORSTR}DDP Rank {RANK}: Using run from {run_url}")
-            self._run = tlc.Run.from_url(run_url)
+            self._load_run_state()
+            LOGGER.info(f"{TLC_COLORSTR}DDP Rank {RANK}: Using run from {self._run.url.to_str()}")
+
+    def _save_run_state(self):
+        """Save the run state to the 3LC run directory."""
+        run_state_file_path = self._3lc_run_dir / RUN_FILE_NAME
+        with open(run_state_file_path, "w") as f:
+            json.dump({"run_url": self._run.url.to_str()}, f)
+
+    def _load_run_state(self):
+        """Load the run state from the 3LC run directory."""
+        run_state_file_path = self._3lc_run_dir / RUN_FILE_NAME
+        with open(run_state_file_path) as f:
+            run_state = json.load(f)
+        self._run = tlc.Run.from_url(run_state["run_url"])
 
     def _handle_tables_argument(self, tables: dict[str, tlc.Table | str | Path | tlc.Url] | None):
         """Handle the tables argument."""
@@ -156,7 +174,7 @@ class TLCTrainerMixin(BaseTrainer):
         and before datasets are created.
         """
 
-        tables_yaml_file_path = (self._3lc_run_dir / "tables_3lc.yaml").absolute()
+        tables_yaml_file_path = (self._3lc_run_dir / TABLES_FILE_NAME).absolute()
 
         # If tables is non-empty
         if self._tables and RANK == -1:
@@ -194,7 +212,7 @@ class TLCTrainerMixin(BaseTrainer):
         For the main node, the settings are written to the temporary 3lc run directory.
         For launched DDP processes, the settings are loaded from the temporary 3lc run directory.
         """
-        settings_yaml_file_path = self._3lc_run_dir / "settings_3lc.yaml"
+        settings_yaml_file_path = self._3lc_run_dir / SETTINGS_FILE_NAME
         if RANK == -1:
             self._settings.to_yaml(settings_yaml_file_path)
         else:

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import tlc
-import yaml
 from ultralytics.engine.trainer import BaseTrainer
-from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK
+from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK, YAML
 from ultralytics.utils.metrics import smooth
 
 from tlc_ultralytics.constants import DEFAULT_TRAIN_RUN_DESCRIPTION, TLC_COLORSTR
-from tlc_ultralytics.engine.utils import _complete_label_column_name, _restore_random_state
+from tlc_ultralytics.engine.utils import (
+    _complete_label_column_name,
+    _handle_deprecated_column_name,
+    _restore_random_state,
+)
 from tlc_ultralytics.settings import Settings
 from tlc_ultralytics.utils import reduce_embeddings
 
@@ -24,35 +28,21 @@ class TLCTrainerMixin(BaseTrainer):
         LOGGER.info("Using 3LC Trainer 🌟")
         self._settings = overrides.pop("settings", Settings())
 
-        # Override settings with image_column_name and label_column_name, both deprecated
-        for column_name in ["image_column_name", "label_column_name"]:
-            if column_name in overrides:
-                msg = (
-                    f"`{column_name}` is deprecated. Provide `{column_name}` to a `Settings` object instead."
-                )
-                LOGGER.warning(f"{TLC_COLORSTR}{msg}")
-
-                value = overrides.pop(column_name)
-
-                if getattr(self._settings, column_name) is not None:
-                    msg = (
-                        f"`{column_name}` is both set in the `Settings` object and provided directly. Using the one "
-                        "from the `Settings` object."
-                    )
-                    LOGGER.warning(f"{TLC_COLORSTR}{msg}")
-
-                else:
-                    setattr(self._settings, column_name, value)
-
-        self._label_column_name = _complete_label_column_name(
+        self.settings.image_column_name = _handle_deprecated_column_name(
+            overrides.pop("image_column_name", None),
+            self._settings.image_column_name,
+            self._default_image_column_name,
+        )
+        self.settings.label_column_name = _handle_deprecated_column_name(
+            overrides.pop("label_column_name", None),
             self._settings.label_column_name,
             self._default_label_column_name,
         )
 
-        if self._settings.image_column_name is None:
-            self._settings.image_column_name = self._default_image_column_name
-
-        self._image_column_name = self._settings.image_column_name
+        self._settings.label_column_name = _complete_label_column_name(
+            self._settings.label_column_name,
+            self._default_label_column_name,
+        )
 
         self._settings.verify(training=True)
 
@@ -84,16 +74,12 @@ class TLCTrainerMixin(BaseTrainer):
         super().__init__(cfg, overrides, _callbacks)
 
         # Handle case where DDP training is used - make settings available to all processes
-        settings_yaml_file_path = self._3lc_run_dir / "settings_3lc.yaml"
-        if RANK in {-1, 0}:
-            self._settings.to_yaml(settings_yaml_file_path)
-        else:
-            self._settings = Settings.from_yaml(settings_yaml_file_path)
+        self._write_load_settings()
 
         self._train_validator = None
         self._train_equals_val_result = None
 
-        if RANK in {-1, 0}:
+        if RANK == -1:
             self._metrics_collection_epochs = set(self._settings.get_metrics_collection_epochs(self.epochs))
 
             # Create a 3LC run
@@ -155,12 +141,19 @@ class TLCTrainerMixin(BaseTrainer):
         LOGGER.info(f"{TLC_COLORSTR}{message}")
 
     def get_dataset(self):
-        tables_yaml_file_path = (self._3lc_run_dir / "tables_3lc.yaml").absolute()
-        self.args.data = f"3LC://{tables_yaml_file_path.as_posix()}"
+        """Override get_dataset to write Table Urls to a 3LC YAML file in the run directory, and set the data
+        argument to the path to this YAML file to make it available to DDP processes.
 
-        # Write table urls to a 3LC YAML file in the run directory
-        if RANK == -1 and self._tables:
-            tables_yaml_file_path.write_text(yaml.safe_dump(self._tables))
+        It is implemented here because it requires access to the run directory, which is set in the parent __init__,
+        and before datasets are created.
+        """
+
+        tables_yaml_file_path = (self._3lc_run_dir / "tables_3lc.yaml").absolute()
+
+        if RANK == -1:
+            YAML.save(tables_yaml_file_path.as_posix(), self._tables or {})
+        else:
+            self.args.data = f"3LC://{tables_yaml_file_path.as_posix()}"
 
         return self._get_dataset()
 
@@ -174,6 +167,30 @@ class TLCTrainerMixin(BaseTrainer):
         run_dir.mkdir(parents=True, exist_ok=True)
 
         return run_dir
+
+    def _move_3lc_run_dir(self):
+        """Move the 3LC specific run artifacts to the Ultralytics run directory."""
+        source_dir = self._3lc_run_dir
+        target_dir = Path(self.save_dir)
+
+        for file in source_dir.glob("*"):
+            shutil.move(file, target_dir / file.name)
+
+        # Verify source dir is empty
+        assert not list(source_dir.glob("*")), "Source directory is not empty"
+        source_dir.rmdir()
+
+    def _write_load_settings(self):
+        """Make settings available to all processes through the run directory.
+
+        For the main node, the settings are written to the temporary 3lc run directory.
+        For launched DDP processes, the settings are loaded from the temporary 3lc run directory.
+        """
+        settings_yaml_file_path = self._3lc_run_dir / "settings_3lc.yaml"
+        if RANK == -1:
+            self._settings.to_yaml(settings_yaml_file_path)
+        else:
+            self._settings = Settings.from_yaml(settings_yaml_file_path)
 
     def _get_dataset(self):
         raise NotImplementedError("Subclasses must implement this method.")
@@ -255,6 +272,7 @@ class TLCTrainerMixin(BaseTrainer):
                     foreign_table_url=foreign_table_url,
                     reducer_args=self._settings.image_embeddings_reducer_args,
                 )
+            self._move_3lc_run_dir()
             self._run.set_status_completed()
 
     def _save_confidence_metrics(self):

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -115,7 +115,7 @@ class TLCTrainerMixin(BaseTrainer):
             {
                 "run_url": self._run.url.to_str(),
                 "settings": self._settings.to_dict(),
-                "data": self.args.data if not self._tables else "",
+                "data": self.args.data,
                 "tables": self._tables if self._tables else None,
             }
         )

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -100,7 +100,9 @@ class TLCTrainerMixin(BaseTrainer):
             self._print_metrics_collection_epochs()
 
     def train(self):
-        """Override the train method to use custom generate_ddp_command function to serialize 3LC data in data argument."""
+        """Override the train method to use custom generate_ddp_command function to serialize 3LC data in data
+        argument.
+        """
         ultralytics.engine.trainer.generate_ddp_command = generate_ddp_command
         super().train()
         ultralytics.engine.trainer.generate_ddp_command = ultralytics.utils.dist.generate_ddp_command

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -70,7 +70,7 @@ class TLCTrainerMixin(BaseTrainer):
             else:
                 self._tables = None
 
-        else: # DDP worker nodes
+        else:  # DDP worker nodes
             try:
                 data = json.loads(overrides["data"])
             except json.JSONDecodeError as e:
@@ -100,8 +100,7 @@ class TLCTrainerMixin(BaseTrainer):
             self._print_metrics_collection_epochs()
 
     def train(self):
-        """Override the train method to use custom generate_ddp_command function to serialize 3LC data in data argument.
-        """
+        """Override the train method to use custom generate_ddp_command function to serialize 3LC data in data argument."""
         ultralytics.engine.trainer.generate_ddp_command = generate_ddp_command
         super().train()
         ultralytics.engine.trainer.generate_ddp_command = ultralytics.utils.dist.generate_ddp_command
@@ -127,18 +126,14 @@ class TLCTrainerMixin(BaseTrainer):
             self._settings.run_description if self._settings.run_description else DEFAULT_TRAIN_RUN_DESCRIPTION
         )
 
-        project_name = (
-            self._settings.project_name if self._settings.project_name else self.data["train"].project_name
-        )
+        project_name = self._settings.project_name if self._settings.project_name else self.data["train"].project_name
         self._run = tlc.init(
             project_name=project_name,
             description=description,
             run_name=self._settings.run_name,
         )
 
-        LOGGER.info(
-            f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}."
-        )
+        LOGGER.info(f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}.")
 
     @staticmethod
     def _handle_tables_argument(tables: dict[str, tlc.Table | str | Path | tlc.Url]) -> dict[str, str]:

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -84,8 +84,8 @@ class TLCTrainerMixin(BaseTrainer):
 
             self._run = tlc.Run.from_url(data["run_url"])
             self._settings = Settings(**data["settings"])
-            self._tables = data["tables"] if "tables" in data else None
-            self.args.data = data["data"] if "data" in data else ""
+            self._tables = data.get("tables", None)
+            overrides["data"] = data.get("data", "")
 
         super().__init__(cfg, overrides, _callbacks)
 

--- a/src/tlc_ultralytics/engine/utils.py
+++ b/src/tlc_ultralytics/engine/utils.py
@@ -1,6 +1,10 @@
 import contextlib
 import random
 
+from ultralytics.utils import LOGGER
+
+from tlc_ultralytics.constants import TLC_COLORSTR
+
 
 def _complete_label_column_name(label_column_name: str, default_label_column_name: str) -> str:
     """Create a complete label column name from a potentially partial one.
@@ -31,3 +35,24 @@ def _restore_random_state():
     state = random.getstate()
     yield
     random.setstate(state)
+
+
+def _handle_deprecated_column_name(arg_value: str | None, settings_value: str | None, default_value: str) -> str:
+    if arg_value is not None:
+        msg = (
+            f"Passing `{arg_value}` as an argument is deprecated. Provide `{arg_value}` to a `Settings` object instead."
+        )
+        LOGGER.warning(f"{TLC_COLORSTR}{msg}")
+
+        if settings_value is not None:
+            msg = (
+                f"`{arg_value}` is both set in the `Settings` object and provided directly. Using the one from the "
+                "`Settings` object."
+            )
+            LOGGER.warning(f"{TLC_COLORSTR}{msg}")
+
+        else:
+            return arg_value
+    elif settings_value is None:
+        return default_value
+    return settings_value

--- a/src/tlc_ultralytics/engine/utils.py
+++ b/src/tlc_ultralytics/engine/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import random
 

--- a/src/tlc_ultralytics/engine/utils.py
+++ b/src/tlc_ultralytics/engine/utils.py
@@ -62,7 +62,7 @@ def _handle_deprecated_column_name(arg_value: str | None, settings_value: str | 
         if settings_value is not None:
             msg = (
                 f"`{arg_value}` is both set in the `Settings` object and provided directly. Using the one passed "
-                "directly."
+                f"directly: '{arg_value}'."
             )
             LOGGER.warning(f"{TLC_COLORSTR}{msg}")
 

--- a/src/tlc_ultralytics/engine/utils.py
+++ b/src/tlc_ultralytics/engine/utils.py
@@ -40,6 +40,19 @@ def _restore_random_state():
 
 
 def _handle_deprecated_column_name(arg_value: str | None, settings_value: str | None, default_value: str) -> str:
+    """Handling for when a column name is passed as an argument directly, instead of through a `Settings` object.
+    Used in the `trainer` and `validator` classes. A warning is logged if the column name is passed as an argument.
+
+    If the column name is provided both through the `Settings` object and as an argument, the one passed directly is
+    used and a warning is logged.
+
+    If the column name is not provided, the default value is returned.
+
+    :param arg_value: The column name passed as an argument directly.
+    :param settings_value: The column name set in the `Settings` object.
+    :param default_value: The default column name.
+    :return: The column name.
+    """
     if arg_value is not None:
         msg = (
             f"Passing `{arg_value}` as an argument is deprecated. Provide `{arg_value}` to a `Settings` object instead."
@@ -48,13 +61,12 @@ def _handle_deprecated_column_name(arg_value: str | None, settings_value: str | 
 
         if settings_value is not None:
             msg = (
-                f"`{arg_value}` is both set in the `Settings` object and provided directly. Using the one from the "
-                "`Settings` object."
+                f"`{arg_value}` is both set in the `Settings` object and provided directly. Using the one passed "
+                "directly."
             )
             LOGGER.warning(f"{TLC_COLORSTR}{msg}")
 
-        else:
-            return arg_value
+        return arg_value
     elif settings_value is None:
         return default_value
     return settings_value

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -22,7 +22,7 @@ from tlc_ultralytics.constants import (
     TLC_COLORSTR,
     TRAINING_PHASE,
 )
-from tlc_ultralytics.engine.utils import _complete_label_column_name
+from tlc_ultralytics.engine.utils import _complete_label_column_name, _handle_deprecated_column_name
 from tlc_ultralytics.settings import Settings
 from tlc_ultralytics.utils import image_embeddings_schema, training_phase_schema
 
@@ -47,11 +47,28 @@ class TLCValidatorMixin(BaseValidator):
         **kwargs,
     ):
         self._run = run
-        self._image_column_name = image_column_name or self._default_image_column_name
-        self._label_column_name = _complete_label_column_name(label_column_name, self._default_label_column_name)
         # Settings can be passed as an argument directly to the validator, or as a keyword from the trainer
         self._settings = settings or kwargs.get("args", {}).pop("settings", None) or Settings()
+
+        self._settings.image_column_name = _handle_deprecated_column_name(
+            image_column_name,
+            self._settings.image_column_name,
+            self._default_image_column_name,
+        )
+        self._settings.label_column_name = _handle_deprecated_column_name(
+            label_column_name,
+            self._settings.label_column_name,
+            self._default_label_column_name,
+        )
+        self._settings.label_column_name = _complete_label_column_name(
+            self._settings.label_column_name,
+            self._default_label_column_name,
+        )
+
         self._training = training
+
+        if not training:
+            self._settings.verify(training=False)
 
         # Table is passed when doing validation only, not when training
         self._table = kwargs.get("args", {}).pop("table", None) if not training else None
@@ -70,8 +87,8 @@ class TLCValidatorMixin(BaseValidator):
             self.data = self.check_dataset(
                 self.args.data,
                 {self.args.split: self._table} if self._table is not None else None,
-                self._image_column_name,
-                self._label_column_name,
+                self._settings.image_column_name,
+                self._settings.label_column_name,
                 project_name=self._settings.project_name,
                 splits=(self.args.split,),
             )

--- a/src/tlc_ultralytics/segment/trainer.py
+++ b/src/tlc_ultralytics/segment/trainer.py
@@ -11,7 +11,7 @@ from tlc_ultralytics.segment.validator import TLCSegmentationValidator
 class TLCSegmentationTrainer(SegmentationTrainer, TLCDetectionTrainer):
     _default_label_column_name = SEGMENTATION_LABEL_COLUMN_NAME
 
-    def get_dataset(self):
+    def _get_dataset(self):
         # Parse yaml and create tables
         self.data = tlc_check_seg_dataset(
             self.args.data,

--- a/src/tlc_ultralytics/segment/trainer.py
+++ b/src/tlc_ultralytics/segment/trainer.py
@@ -11,7 +11,7 @@ from tlc_ultralytics.segment.validator import TLCSegmentationValidator
 class TLCSegmentationTrainer(SegmentationTrainer, TLCDetectionTrainer):
     _default_label_column_name = SEGMENTATION_LABEL_COLUMN_NAME
 
-    def _get_dataset(self):
+    def get_dataset(self):
         # Parse yaml and create tables
         self.data = tlc_check_seg_dataset(
             self.args.data,

--- a/src/tlc_ultralytics/segment/trainer.py
+++ b/src/tlc_ultralytics/segment/trainer.py
@@ -16,8 +16,8 @@ class TLCSegmentationTrainer(SegmentationTrainer, TLCDetectionTrainer):
         self.data = tlc_check_seg_dataset(
             self.args.data,
             self._tables,
-            self._image_column_name,
-            self._label_column_name,
+            self._settings.image_column_name,
+            self._settings.label_column_name,
             project_name=self._settings.project_name,
             splits=("train", "val"),
         )
@@ -27,8 +27,8 @@ class TLCSegmentationTrainer(SegmentationTrainer, TLCDetectionTrainer):
             data_test = tlc_check_seg_dataset(
                 self.args.data,
                 self._tables,
-                self._image_column_name,
-                self._label_column_name,
+                self._settings.image_column_name,
+                self._settings.label_column_name,
                 project_name=self._settings.project_name,
                 splits=("test",),
             )

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -149,11 +149,7 @@ class Settings:
 
         :param yaml_file_path: The path to the YAML file to save the settings to.
         """
-        content = {
-            k: v
-            for k, v in self.__dict__.items()
-            if k not in ("metrics_collection_function", "metrics_schemas") and not k.startswith("_")
-        }
+        content = self._get_dict_to_serialize()
         YAML.save(yaml_file_path.as_posix(), content)
 
     @classmethod
@@ -164,6 +160,24 @@ class Settings:
         :returns: A Settings instance.
         """
         return cls(**YAML.load(yaml_file_path.as_posix()))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the settings to a dictionary.
+
+        :returns: A dictionary with the settings.
+        """
+        return self._get_dict_to_serialize()
+
+    def _get_dict_to_serialize(self) -> dict[str, Any]:
+        """Get the dictionary to serialize.
+
+        :returns: A dictionary with the settings.
+        """
+        return {
+            k: v
+            for k, v in self.__dict__.items()
+            if k not in ("metrics_collection_function", "metrics_schemas") and not k.startswith("_")
+        }
 
     def verify(self, training: bool = True) -> None:
         """Verify that the settings are valid.

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -4,9 +4,11 @@ import importlib
 import os
 from dataclasses import dataclass, field, fields
 from difflib import get_close_matches
+from pathlib import Path
 from typing import Any, Callable
 
 import tlc
+import yaml
 from ultralytics.utils import LOGGER
 
 from tlc_ultralytics.constants import TLC_COLORSTR
@@ -109,6 +111,12 @@ class Settings:
 
     Default: None"""
 
+    image_column_name: str | None = field(default=None)
+    """The name of the image column in the dataset. Default: None"""
+
+    label_column_name: str | None = field(default=None)
+    """The name of the label column or full value path to the label. Default: None"""
+
     @classmethod
     def from_env(cls) -> Settings:
         """Create a Settings instance from environment variables.
@@ -136,6 +144,28 @@ class Settings:
         # Mark as not created from environment variables
         if not hasattr(self, "_from_env"):
             self._from_env = False
+
+    def to_yaml(self, yaml_file_path: Path) -> None:
+        """Save the settings to a YAML file.
+
+        :param yaml_file_path: The path to the YAML file to save the settings to.
+        """
+        content = {
+            k: v
+            for k, v in self.__dict__.items()
+            if k not in ("metrics_collection_function", "metrics_schemas")
+            and not k.startswith("_")
+        }
+        yaml_file_path.write_text(yaml.safe_dump(content))
+
+    @classmethod
+    def from_yaml(cls, yaml_file_path: Path) -> Settings:
+        """Create a Settings instance from a JSON string.
+
+        :param json_str: A JSON string representing the settings.
+        :returns: A Settings instance.
+        """
+        return cls(**yaml.safe_load(yaml_file_path.read_text()))
 
     def verify(self, training: bool = True) -> None:
         """Verify that the settings are valid.

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -4,11 +4,10 @@ import importlib
 import os
 from dataclasses import dataclass, field, fields
 from difflib import get_close_matches
-from pathlib import Path
 from typing import Any, Callable
 
 import tlc
-from ultralytics.utils import LOGGER, YAML
+from ultralytics.utils import LOGGER
 
 from tlc_ultralytics.constants import TLC_COLORSTR
 
@@ -143,23 +142,6 @@ class Settings:
         # Mark as not created from environment variables
         if not hasattr(self, "_from_env"):
             self._from_env = False
-
-    def to_yaml(self, yaml_file_path: Path) -> None:
-        """Save the settings to a YAML file.
-
-        :param yaml_file_path: The path to the YAML file to save the settings to.
-        """
-        content = self._get_dict_to_serialize()
-        YAML.save(yaml_file_path.as_posix(), content)
-
-    @classmethod
-    def from_yaml(cls, yaml_file_path: Path) -> Settings:
-        """Create a Settings instance from a JSON string.
-
-        :param json_str: A JSON string representing the settings.
-        :returns: A Settings instance.
-        """
-        return cls(**YAML.load(yaml_file_path.as_posix()))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the settings to a dictionary.

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -8,8 +8,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import tlc
-import yaml
-from ultralytics.utils import LOGGER
+from ultralytics.utils import LOGGER, YAML
 
 from tlc_ultralytics.constants import TLC_COLORSTR
 
@@ -111,8 +110,8 @@ class Settings:
 
     Default: None"""
 
-    image_column_name: str | None = field(default=None)
-    """The name of the image column in the dataset. Default: None"""
+    image_column_name: str = "image"
+    """The name of the image column in the dataset. Default: 'image'"""
 
     label_column_name: str | None = field(default=None)
     """The name of the label column or full value path to the label. Default: None"""
@@ -153,10 +152,9 @@ class Settings:
         content = {
             k: v
             for k, v in self.__dict__.items()
-            if k not in ("metrics_collection_function", "metrics_schemas")
-            and not k.startswith("_")
+            if k not in ("metrics_collection_function", "metrics_schemas") and not k.startswith("_")
         }
-        yaml_file_path.write_text(yaml.safe_dump(content))
+        YAML.save(yaml_file_path.as_posix(), content)
 
     @classmethod
     def from_yaml(cls, yaml_file_path: Path) -> Settings:
@@ -165,7 +163,7 @@ class Settings:
         :param json_str: A JSON string representing the settings.
         :returns: A Settings instance.
         """
-        return cls(**yaml.safe_load(yaml_file_path.read_text()))
+        return cls(**YAML.load(yaml_file_path.as_posix()))
 
     def verify(self, training: bool = True) -> None:
         """Verify that the settings are valid.
@@ -188,6 +186,8 @@ class Settings:
             assert callable(self.metrics_collection_function), (
                 f"metrics_collection_function must be callable, got {type(self.metrics_collection_function)}"
             )
+
+        assert self.label_column_name is not None, "label_column_name must be set, got None"
 
         # Train / collect specific settings
         self._verify_training() if training else self._verify_collection()

--- a/src/tlc_ultralytics/utils/dataset.py
+++ b/src/tlc_ultralytics/utils/dataset.py
@@ -100,6 +100,7 @@ def check_tlc_dataset(  # noqa: C901
 
     else:
         # LOGGER.info(f"{TLC_COLORSTR}Using data directly from tables")
+        tables = tables.copy()
         _check_tables(tables)
 
         for key, table in tables.items():

--- a/src/tlc_ultralytics/utils/dataset.py
+++ b/src/tlc_ultralytics/utils/dataset.py
@@ -35,12 +35,17 @@ def check_tlc_dataset(  # noqa: C901
     :return: Dictionary of tables and class names
     """
 
-    if not tables and data is not None and data.endswith(".ndjson"):
-        raise ValueError(
+    if not tables and not isinstance(data, (str, Path)):
+        msg = "`data` must be a string. If you are passing tables directly, use the `tables` argument instead."
+        raise ValueError(msg)
+
+    if not tables and isinstance(data, str) and data.endswith(".ndjson"):
+        msg = (
             "NDJson datasets are not yet supported in the YOLO integration. Create a tlc.Table from the ",
             "data or convert it to a YOLO dataset and use `tlc.Table.from_yolo`. The NDJson format will be ",
             "supported in the future.",
         )
+        raise ValueError(msg)
 
     # If the data starts with the 3LC prefix, parse the YAML file and populate `tables`
     has_prefix = False

--- a/src/tlc_ultralytics/utils/generate_ddp.py
+++ b/src/tlc_ultralytics/utils/generate_ddp.py
@@ -1,0 +1,12 @@
+from ultralytics.utils.dist import generate_ddp_command as ultralytics_generate_ddp_command
+
+
+def generate_ddp_command(world_size,trainer) -> str:
+    """Override the generate_ddp_command function to serialize the 3LC data required for DDP processes
+    as part of the data argument. The override is temporary and therefore does not alter the original trainer state.
+    """
+    original_data = trainer.args.data
+    trainer.args.data = trainer._serialize_state()
+    command = ultralytics_generate_ddp_command(world_size, trainer)
+    trainer.args.data = original_data
+    return command

--- a/src/tlc_ultralytics/utils/generate_ddp.py
+++ b/src/tlc_ultralytics/utils/generate_ddp.py
@@ -1,7 +1,7 @@
 from ultralytics.utils.dist import generate_ddp_command as ultralytics_generate_ddp_command
 
 
-def generate_ddp_command(world_size,trainer) -> str:
+def generate_ddp_command(world_size, trainer) -> str:
     """Override the generate_ddp_command function to serialize the 3LC data required for DDP processes
     as part of the data argument. The override is temporary and therefore does not alter the original trainer state.
     """

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -173,6 +173,12 @@ def test_training(task) -> None:
     settings_loaded = Settings.from_yaml(results_3lc.save_dir / "settings_3lc.yaml")
     assert settings_loaded.project_name == settings.project_name, "Project name mismatch"
 
+    run_state_file_path = results_3lc.save_dir / "run.json"
+    assert run_state_file_path.exists(), "Run state file not found"
+    with open(run_state_file_path) as f:
+        run_state = json.load(f)
+    assert run_state["run_url"] == results_3lc.run_url, "Run state mismatch"
+
     # Get 3LC run and inspect the results
     run = _get_run_from_settings(settings)
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -177,7 +177,7 @@ def test_training(task) -> None:
     assert run_state_file_path.exists(), "Run state file not found"
     with open(run_state_file_path) as f:
         run_state = json.load(f)
-    assert run_state["run_url"] == results_3lc.run_url, "Run state mismatch"
+    assert run_state["run_url"] == results_3lc.run_url.to_str(), "Run state mismatch"
 
     # Get 3LC run and inspect the results
     run = _get_run_from_settings(settings)

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -1279,6 +1279,7 @@ def test_settings_serialization() -> None:
     assert settings_from_dict.run_name == settings.run_name
     assert settings_from_dict.image_embeddings_reducer == settings.image_embeddings_reducer
 
+
 # HELPERS
 
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -169,16 +169,6 @@ def test_training(task) -> None:
 
     assert results_ultralytics.names == results_3lc.names, "Results validation names"
 
-    # Check that the settings were saved
-    settings_loaded = Settings.from_yaml(results_3lc.save_dir / "settings_3lc.yaml")
-    assert settings_loaded.project_name == settings.project_name, "Project name mismatch"
-
-    run_state_file_path = results_3lc.save_dir / "run.json"
-    assert run_state_file_path.exists(), "Run state file not found"
-    with open(run_state_file_path) as f:
-        run_state = json.load(f)
-    assert run_state["run_url"] == results_3lc.run_url.to_str(), "Run state mismatch"
-
     # Get 3LC run and inspect the results
     run = _get_run_from_settings(settings)
 
@@ -1257,7 +1247,7 @@ def test_dataset_cache(task) -> None:
 
 
 def test_bad_arguments() -> None:
-    """Test that bad arguments are caught early and an error is raised gracefully"""
+    """Test that bad arguments are caught early and an error is raised"""
     model = TLCYOLO(TASK2MODEL["detect"])
 
     train_table = tlc.Table.from_dict(

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -1272,28 +1272,12 @@ def test_settings_serialization() -> None:
         metrics_collection_function=lambda x, y: {"test_metric": [1] * len(x)},
     )
 
-    settings.to_yaml(TMP / "settings_3lc.yaml")
+    settings_dict = settings.to_dict()
+    settings_from_dict = Settings(**settings_dict)
 
-    settings_loaded = Settings.from_yaml(TMP / "settings_3lc.yaml")
-
-    # Non-default values should be the same
-    assert settings_loaded.project_name == settings.project_name
-    assert settings_loaded.run_name == settings.run_name
-    assert settings_loaded.image_embeddings_reducer == settings.image_embeddings_reducer
-    assert settings_loaded.image_embeddings_dim == settings.image_embeddings_dim
-    assert settings_loaded.exclude_zero_weight_training == settings.exclude_zero_weight_training
-
-    # Default values should be the same
-    assert settings_loaded.conf_thres == settings.conf_thres
-    assert settings_loaded.max_det == settings.max_det
-    assert settings_loaded.collect_loss == settings.collect_loss
-    assert settings_loaded.metrics_schemas == settings.metrics_schemas
-    assert settings_loaded.image_column_name == settings.image_column_name
-    assert settings_loaded.label_column_name == settings.label_column_name
-
-    # Metrics collection function is not serialized
-    assert settings_loaded.metrics_collection_function is None
-
+    assert settings_from_dict.project_name == settings.project_name
+    assert settings_from_dict.run_name == settings.run_name
+    assert settings_from_dict.image_embeddings_reducer == settings.image_embeddings_reducer
 
 # HELPERS
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -169,6 +169,15 @@ def test_training(task) -> None:
 
     assert results_ultralytics.names == results_3lc.names, "Results validation names"
 
+    # Ensure the trainer can be serialized
+    trainer_serialized = model_3lc.trainer._serialize_state()
+    assert isinstance(trainer_serialized, str), "Trainer serialization failed"
+    trainer_json_content = json.loads(trainer_serialized)
+    assert trainer_json_content["run_url"] == model_3lc.trainer._run.url.to_str(), "Run URL mismatch"
+    assert trainer_json_content["settings"] == model_3lc.trainer._settings.to_dict(), "Settings mismatch"
+    assert trainer_json_content["data"] == model_3lc.trainer.args.data, "Data mismatch"
+    assert trainer_json_content["tables"] == model_3lc.trainer._tables, "Tables mismatch"
+
     # Get 3LC run and inspect the results
     run = _get_run_from_settings(settings)
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -169,6 +169,10 @@ def test_training(task) -> None:
 
     assert results_ultralytics.names == results_3lc.names, "Results validation names"
 
+    # Check that the settings were saved
+    settings_loaded = Settings.from_yaml(results_3lc.save_dir / "settings_3lc.yaml")
+    assert settings_loaded.project_name == settings.project_name, "Project name mismatch"
+
     # Get 3LC run and inspect the results
     run = _get_run_from_settings(settings)
 
@@ -1260,6 +1264,39 @@ def test_bad_arguments() -> None:
     # Data is used instead of tables
     with pytest.raises(ValueError):
         model.train(data={"train": train_table, "val": val_table})
+
+
+def test_settings_serialization() -> None:
+    settings = Settings(
+        project_name="test_settings_serialization",
+        run_name="test_settings_serialization",
+        image_embeddings_reducer="umap",
+        image_embeddings_dim=2,
+        exclude_zero_weight_training=True,
+        metrics_collection_function=lambda x, y: {"test_metric": [1] * len(x)},
+    )
+
+    settings.to_yaml(TMP / "settings_3lc.yaml")
+
+    settings_loaded = Settings.from_yaml(TMP / "settings_3lc.yaml")
+
+    # Non-default values should be the same
+    assert settings_loaded.project_name == settings.project_name
+    assert settings_loaded.run_name == settings.run_name
+    assert settings_loaded.image_embeddings_reducer == settings.image_embeddings_reducer
+    assert settings_loaded.image_embeddings_dim == settings.image_embeddings_dim
+    assert settings_loaded.exclude_zero_weight_training == settings.exclude_zero_weight_training
+
+    # Default values should be the same
+    assert settings_loaded.conf_thres == settings.conf_thres
+    assert settings_loaded.max_det == settings.max_det
+    assert settings_loaded.collect_loss == settings.collect_loss
+    assert settings_loaded.metrics_schemas == settings.metrics_schemas
+    assert settings_loaded.image_column_name == settings.image_column_name
+    assert settings_loaded.label_column_name == settings.label_column_name
+
+    # Metrics collection function is not serialized
+    assert settings_loaded.metrics_collection_function is None
 
 
 # HELPERS

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -1410,7 +1410,7 @@ def _create_test_image_and_table() -> tuple[pathlib.Path, tuple[tlc.Table, tlc.T
 
     yolo_dataset_file = _create_no_predictions_data_yaml(data_set_path)
 
-    table_train = tlc.Table.from_yolo(yolo_dataset_file, "train", if_exists="overwrite")
-    table_val = tlc.Table.from_yolo(yolo_dataset_file, "val", if_exists="overwrite")
+    table_train = tlc.Table.from_yolo(yolo_dataset_file, "train", if_exists="overwrite", dataset_name="train")
+    table_val = tlc.Table.from_yolo(yolo_dataset_file, "val", if_exists="overwrite", dataset_name="val")
 
     return yolo_dataset_file, (table_train, table_val)


### PR DESCRIPTION
This PR fixes a problem causing Distributed Data Parallel (DDP) training to fail when passing `tables` directly.

The `image_column_name` and `label_column_name` arguments on `model.train` and `model.val` are deprecated in favor of new `Settings` properties `image_column_name` and `label_column_name`.