### PR TITLE
Pipelines: Add support for running tests on Windows and Mac + Make it possible to test without making a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,74 +55,74 @@ jobs:
           ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
           ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
 
-  build-and-publish:
-    needs: test
-    environment: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # build-and-publish:
+  #   needs: test
+  #   environment: release
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     id-token: write
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.10'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          version: "0.7.19"
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v2
+  #       with:
+  #         version: "0.7.19"
 
-      - name: Get version from pyproject.toml
-        id: version
-        run: |
-          VERSION=$(uv version --output-format json | jq -r '.version')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Using version: $VERSION"
+  #     - name: Get version from pyproject.toml
+  #       id: version
+  #       run: |
+  #         VERSION=$(uv version --output-format json | jq -r '.version')
+  #         echo "version=$VERSION" >> $GITHUB_OUTPUT
+  #         echo "Using version: $VERSION"
 
-      - name: Extract changelog section
-        id: changelog
-        run: |
-          # Extract the changelog section for this version
-          VERSION="${{ steps.version.outputs.version }}"
-          CHANGELOG_CONTENT=$(awk -v version="$VERSION" '
-            BEGIN { in_section = 0; content = "" }
-            /^## \['"$VERSION"'\]/ { in_section = 1; next }
-            /^## \[/ && in_section { exit }
-            in_section { content = content $0 "\n" }
-            END { print content }
-          ' CHANGELOG.md | sed '/^$/d')
+  #     - name: Extract changelog section
+  #       id: changelog
+  #       run: |
+  #         # Extract the changelog section for this version
+  #         VERSION="${{ steps.version.outputs.version }}"
+  #         CHANGELOG_CONTENT=$(awk -v version="$VERSION" '
+  #           BEGIN { in_section = 0; content = "" }
+  #           /^## \['"$VERSION"'\]/ { in_section = 1; next }
+  #           /^## \[/ && in_section { exit }
+  #           in_section { content = content $0 "\n" }
+  #           END { print content }
+  #         ' CHANGELOG.md | sed '/^$/d')
           
-          # Store the raw changelog content (GitHub Actions handles newlines properly)
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "Extracted changelog for version $VERSION"
+  #         # Store the raw changelog content (GitHub Actions handles newlines properly)
+  #         echo "changelog<<EOF" >> $GITHUB_OUTPUT
+  #         echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
+  #         echo "EOF" >> $GITHUB_OUTPUT
+  #         echo "Extracted changelog for version $VERSION"
 
-      - name: Build package
-        run: |
-          uv build --no-sources
+  #     - name: Build package
+  #       run: |
+  #         uv build --no-sources
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: Release v${{ steps.version.outputs.version }}
-          body: |
-            ${{ steps.changelog.outputs.changelog }}
+  #     - name: Create GitHub Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         tag_name: v${{ steps.version.outputs.version }}
+  #         name: Release v${{ steps.version.outputs.version }}
+  #         body: |
+  #           ${{ steps.changelog.outputs.changelog }}
             
-            ## Installation
+  #           ## Installation
             
-            ```bash
-            pip install 3lc-ultralytics==${{ steps.version.outputs.version }}
-            ```
-          draft: false
-          prerelease: false
-          generate_release_notes: false 
+  #           ```bash
+  #           pip install 3lc-ultralytics==${{ steps.version.outputs.version }}
+  #           ```
+  #         draft: false
+  #         prerelease: false
+  #         generate_release_notes: false 
 
-      - name: Publish to PyPI
-        run: |
-          uv publish
+  #     - name: Publish to PyPI
+  #       run: |
+  #         uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,19 +41,19 @@ jobs:
 
       - name: Run tests with Python 3.10
         run: |
-          export "${{ secrets.VARIABLE_NAME }}=${{ secrets.VARIABLE_VALUE }}"
-          export "${{ secrets.RUNTIME_NAME }}=${{ secrets.RUNTIME_VALUE }}"
           uv run --python 3.10 --no-sources pytest tests/ -v -n 1
         env:
           TLC_API_KEY: ${{ secrets.TLC_API_KEY }}
+          ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
+          ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
 
       - name: Run tests with Python 3.13 for highest resolution
         run: |
-          export "${{ secrets.VARIABLE_NAME }}=${{ secrets.VARIABLE_VALUE }}"
-          export "${{ secrets.RUNTIME_NAME }}=${{ secrets.RUNTIME_VALUE }}"
           uv run --resolution highest --python 3.13 --no-sources pytest tests/ -v -n 1
         env:
           TLC_API_KEY: ${{ secrets.TLC_API_KEY }}
+          ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
+          ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
 
   build-and-publish:
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           uv sync --group dev --no-sources
 
       - name: Run linting
+        if: matrix.os == 'ubuntu-latest'
         run: |
           uv run --no-sources ruff check .
 
@@ -48,6 +49,7 @@ jobs:
           ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
 
       - name: Run tests with Python 3.13 for highest resolution
+        if: matrix.os == 'ubuntu-latest'
         run: |
           uv run --resolution highest --python 3.13 --no-sources pytest tests/ -v -n 1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
     tags:
       - 'v0.*.*'
   workflow_dispatch:
-    # inputs:
-      # version:
-      #   description: 'Version to release (e.g., 0.1.0)'
-      #   required: true
-      #   type: string
+    inputs:
+      version:
+        description: 'Version to release (e.g., 0.1.0)'
+        required: true
+        type: string
 
 jobs:
   test:
@@ -57,74 +57,74 @@ jobs:
           ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
           ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
 
-  # build-and-publish:
-  #   needs: test
-  #   environment: release
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #     id-token: write
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  build-and-publish:
+    needs: test
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.10'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
-  #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v2
-  #       with:
-  #         version: "0.7.19"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.7.19"
 
-  #     - name: Get version from pyproject.toml
-  #       id: version
-  #       run: |
-  #         VERSION=$(uv version --output-format json | jq -r '.version')
-  #         echo "version=$VERSION" >> $GITHUB_OUTPUT
-  #         echo "Using version: $VERSION"
+      - name: Get version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(uv version --output-format json | jq -r '.version')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Using version: $VERSION"
 
-  #     - name: Extract changelog section
-  #       id: changelog
-  #       run: |
-  #         # Extract the changelog section for this version
-  #         VERSION="${{ steps.version.outputs.version }}"
-  #         CHANGELOG_CONTENT=$(awk -v version="$VERSION" '
-  #           BEGIN { in_section = 0; content = "" }
-  #           /^## \['"$VERSION"'\]/ { in_section = 1; next }
-  #           /^## \[/ && in_section { exit }
-  #           in_section { content = content $0 "\n" }
-  #           END { print content }
-  #         ' CHANGELOG.md | sed '/^$/d')
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          # Extract the changelog section for this version
+          VERSION="${{ steps.version.outputs.version }}"
+          CHANGELOG_CONTENT=$(awk -v version="$VERSION" '
+            BEGIN { in_section = 0; content = "" }
+            /^## \['"$VERSION"'\]/ { in_section = 1; next }
+            /^## \[/ && in_section { exit }
+            in_section { content = content $0 "\n" }
+            END { print content }
+          ' CHANGELOG.md | sed '/^$/d')
           
-  #         # Store the raw changelog content (GitHub Actions handles newlines properly)
-  #         echo "changelog<<EOF" >> $GITHUB_OUTPUT
-  #         echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
-  #         echo "EOF" >> $GITHUB_OUTPUT
-  #         echo "Extracted changelog for version $VERSION"
+          # Store the raw changelog content (GitHub Actions handles newlines properly)
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Extracted changelog for version $VERSION"
 
-  #     - name: Build package
-  #       run: |
-  #         uv build --no-sources
+      - name: Build package
+        run: |
+          uv build --no-sources
 
-  #     - name: Create GitHub Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         tag_name: v${{ steps.version.outputs.version }}
-  #         name: Release v${{ steps.version.outputs.version }}
-  #         body: |
-  #           ${{ steps.changelog.outputs.changelog }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
             
-  #           ## Installation
+            ## Installation
             
-  #           ```bash
-  #           pip install 3lc-ultralytics==${{ steps.version.outputs.version }}
-  #           ```
-  #         draft: false
-  #         prerelease: false
-  #         generate_release_notes: false 
+            ```bash
+            pip install 3lc-ultralytics==${{ steps.version.outputs.version }}
+            ```
+          draft: false
+          prerelease: false
+          generate_release_notes: false 
 
-  #     - name: Publish to PyPI
-  #       run: |
-  #         uv publish
+      - name: Publish to PyPI
+        run: |
+          uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,49 +13,7 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          version: "latest"
-
-      - name: Install dependencies
-        run: |
-          uv sync --group dev --no-sources
-
-      - name: Run linting
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          uv run --no-sources ruff check .
-
-      - name: Run tests with Python 3.10
-        run: |
-          uv run --python 3.10 --no-sources pytest tests/ -v -n 1
-        env:
-          TLC_API_KEY: ${{ secrets.TLC_API_KEY }}
-          ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
-          ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
-
-      - name: Run tests with Python 3.13 for highest resolution
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          uv run --resolution highest --python 3.13 --no-sources pytest tests/ -v -n 1
-        env:
-          TLC_API_KEY: ${{ secrets.TLC_API_KEY }}
-          ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
-          ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
+    uses: ./.github/workflows/test.yml
 
   build-and-publish:
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
     tags:
       - 'v0.*.*'
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g., 0.1.0)'
-        required: true
-        type: string
+    # inputs:
+      # version:
+      #   description: 'Version to release (e.g., 0.1.0)'
+      #   required: true
+      #   type: string
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Test
 on:
   workflow_call:
   workflow_dispatch:
-  push:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   workflow_call:
   workflow_dispatch:
+  push:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev --no-sources
+
+      - name: Run linting
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          uv run --no-sources ruff check .
+
+      - name: Run tests with Python 3.10
+        run: |
+          uv run --python 3.10 --no-sources pytest tests/ -v -n 1
+        env:
+          TLC_API_KEY: ${{ secrets.TLC_API_KEY }}
+          ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
+          ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}
+
+      - name: Run tests with Python 3.13 for highest resolution
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          uv run --resolution highest --python 3.13 --no-sources pytest tests/ -v -n 1
+        env:
+          TLC_API_KEY: ${{ secrets.TLC_API_KEY }}
+          ${{ secrets.VARIABLE_NAME }}: ${{ secrets.VARIABLE_VALUE }}
+          ${{ secrets.RUNTIME_NAME }}: ${{ secrets.RUNTIME_VALUE }}


### PR DESCRIPTION
- Make it possible to test without making a release by moving testing into a dedicated test.yml independent from (but called by) release.yml
- Add support for running tests on Windows and Mac (in addition to Ubuntu)