### PR TITLE
Use stream_name kwarg on MetricsTableWriter for per-class metrics

### DIFF
--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -402,6 +402,7 @@ class TLCValidatorMixin(BaseValidator):
         metrics_writer = tlc.MetricsTableWriter(
             run_url=self._run.url,
             schema=self._per_class_metrics_schemas(),
+            stream_name=PER_CLASS_METRICS_STREAM_NAME,
         )
 
         epoch = self._epoch + 1 if self._epoch is not None else -1
@@ -429,12 +430,6 @@ class TLCValidatorMixin(BaseValidator):
 
         metrics_writer.add_batch(metrics_batch)
         metrics_writer.finalize()
-        metrics_infos = metrics_writer.get_written_metrics_infos()
-        for m in metrics_infos:
-            # Set the stream name to the per-class metrics stream
-            # TODO: This should be a constructor argument to MetricsTableWriter
-            m["stream_name"] = PER_CLASS_METRICS_STREAM_NAME
-        self._run.update_metrics(metrics_infos)
 
     def _per_class_metrics_schemas(self):
         metrics_schemas = {

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -265,6 +265,17 @@ def test_training(task: str) -> None:
 
     # Check that there is a per-epoch value written
     assert len(run.constants["outputs"]) > 0, "No outputs written"
+
+    # Each metrics table URL must be registered under exactly one stream. A previous bug had
+    # the per-class writer auto-register under default_stream and then re-register under
+    # per_class_metrics, which polluted default_stream with per-class rows lacking
+    # example_id/predictions, breaking dashboard rendering.
+    url_streams: dict[str, list[str]] = defaultdict(list)
+    for info in run.metrics:
+        url_streams[info["url"]].append(info["stream_name"])
+    duplicates = {url: streams for url, streams in url_streams.items() if len(streams) > 1}
+    assert not duplicates, f"Metrics URLs registered under multiple streams: {duplicates}"
+
     metrics_tables = get_metrics_tables_from_run(run)
 
     # Check that the desired metrics were written


### PR DESCRIPTION
Pass stream_name=PER_CLASS_METRICS_STREAM_NAME at construction instead of mutating the metric_info dict after finalize() and re-registering it. The old pattern left a stale "default_stream" entry pointing at the same URL as the per_class_metrics one; the dashboard joins by column signature and silently drops the tab label when entries in a group disagree on stream name, so per-class predictions appeared empty.

Add a regression assertion in test_training[task] that no metrics URL is registered under more than one stream.

Requires the matching stream_name kwarg in 3lc MetricsTableWriter.