### PR TITLE
Handle empty and dimensionless annotations across instance tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Since this package integrates with two actively developed dependencies (`ultraly
 ### Changed
 
 - Widen the supported `ultralytics` range from `>=8.4.0,<8.4.7` to `>=8.4.0,<8.4.67`.
+- Training and metrics collection fall back to reading dimensions from image files as a fallback when annotations store non-positive image dimensions (e.g. `image_height`/`image_width` of `0`) and emits a warning in this case.
+
+### Fixed
+
+- Fix error when training on segmentation, OBB or pose tables containing unlabeled rows. Such rows are now correctly treated as having zero instances.
 
 ## [0.3.1] - 2026-06-04
 

--- a/src/tlc_ultralytics/detect/dataset.py
+++ b/src/tlc_ultralytics/detect/dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+from tlc.constants import IMAGE_HEIGHT, IMAGE_WIDTH
 from tlc.data_types import BoundingBoxes2D, SegmentationPolygons
 from tlc.helpers import AnnotationHelper, AnnotationType
 from ultralytics.data.dataset import YOLODataset
@@ -204,8 +205,12 @@ class TLCYOLODetectionDataset(BaseTLCYOLODataset):
         else:
             bb2d = BoundingBoxes2D.from_row(raw)
 
-        height = bb2d.y_max - (bb2d.y_min or 0)
-        width = bb2d.x_max - (bb2d.x_min or 0)
+        # The coordinate-space bounds carry the image dimensions (boxes are stored as absolute
+        # xyxy pixels). Fall back to the real image size if they are missing or non-positive.
+        height = bb2d.y_max - (bb2d.y_min or 0) if bb2d.y_max else 0
+        width = bb2d.x_max - (bb2d.x_min or 0) if bb2d.x_max else 0
+        if height <= 0 or width <= 0:
+            height, width = self._resolve_image_dimensions(im_file)
 
         if bb2d.num_instances == 0 or bb2d.labels is None:
             return {
@@ -289,17 +294,26 @@ class TLCYOLOSegmentationDataset(BaseTLCYOLODataset):
         """
         column_name, _, _ = self._label_column_name.split(".")
 
-        # Use sample view to get polygons, row is row view
+        # The row view holds the raw, serialized segmentation dict.
         row = self.table.table_rows[example_id]
         raw_segmentations = row[column_name]
+
+        # Fall back to image file dimensions when unavailable
+        if raw_segmentations[IMAGE_HEIGHT] <= 0 or raw_segmentations[IMAGE_WIDTH] <= 0:
+            height, width = self._resolve_image_dimensions(im_file)
+            raw_segmentations = {**raw_segmentations, IMAGE_HEIGHT: height, IMAGE_WIDTH: width}
+
         segmentations = SegmentationPolygons.from_row(raw_segmentations).to_relative()
         height, width = segmentations.image_height, segmentations.image_width
         classes = []
         segments = []
 
+        # Unlabeled rows come back with `labels=None`
+        labels = segmentations.labels if segmentations.labels is not None else []
+
         for i, (category, polygon) in enumerate(
             zip(
-                segmentations.labels,
+                labels,
                 segmentations.polygons,
                 strict=False,
             )

--- a/src/tlc_ultralytics/detect/dataset.py
+++ b/src/tlc_ultralytics/detect/dataset.py
@@ -209,8 +209,7 @@ class TLCYOLODetectionDataset(BaseTLCYOLODataset):
         # xyxy pixels). Fall back to the real image size if they are missing or non-positive.
         height = bb2d.y_max - (bb2d.y_min or 0) if bb2d.y_max else 0
         width = bb2d.x_max - (bb2d.x_min or 0) if bb2d.x_max else 0
-        if height <= 0 or width <= 0:
-            height, width = self._resolve_image_dimensions(im_file)
+        height, width = self._resolve_image_dimensions(im_file, height, width)
 
         if bb2d.num_instances == 0 or bb2d.labels is None:
             return {
@@ -298,10 +297,12 @@ class TLCYOLOSegmentationDataset(BaseTLCYOLODataset):
         row = self.table.table_rows[example_id]
         raw_segmentations = row[column_name]
 
-        # Fall back to image file dimensions when unavailable
-        if raw_segmentations[IMAGE_HEIGHT] <= 0 or raw_segmentations[IMAGE_WIDTH] <= 0:
-            height, width = self._resolve_image_dimensions(im_file)
-            raw_segmentations = {**raw_segmentations, IMAGE_HEIGHT: height, IMAGE_WIDTH: width}
+        # Masks are RLE-encoded and the size is reconstructed solely from the stored dimensions,
+        # so they must be valid before decoding - inject the resolved dimensions into the row.
+        height, width = self._resolve_image_dimensions(
+            im_file, raw_segmentations[IMAGE_HEIGHT], raw_segmentations[IMAGE_WIDTH]
+        )
+        raw_segmentations = {**raw_segmentations, IMAGE_HEIGHT: height, IMAGE_WIDTH: width}
 
         segmentations = SegmentationPolygons.from_row(raw_segmentations).to_relative()
         height, width = segmentations.image_height, segmentations.image_width

--- a/src/tlc_ultralytics/engine/dataset.py
+++ b/src/tlc_ultralytics/engine/dataset.py
@@ -6,6 +6,7 @@ from multiprocessing.pool import ThreadPool
 from typing import TYPE_CHECKING, Any
 
 import tlc
+from tlc.helpers import ImageHelper
 from ultralytics.data.utils import verify_image
 from ultralytics.utils import LOGGER, NUM_THREADS, TQDM, colorstr
 
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
 # Responsible for any generic 3LC dataset handling, such as scanning, caching and adding example ids to each sample
 # Assume there is an attribute self.table that is a tlc.Table
 class TLCDatasetMixin:
+    _warned_missing_image_dimensions = False
+
     def _post_init(self):
         self.display_name = self.table.dataset_name
 
@@ -58,6 +61,27 @@ class TLCDatasetMixin:
             raise ValueError(msg)
 
         return url.to_absolute(table_url).to_str()
+
+    def _resolve_image_dimensions(self, im_file: str) -> tuple[int, int]:
+        """Read the ``(height, width)`` of an image from disk.
+
+        Used as a fallback when a Table stores non-positive annotation dimensions (e.g. an
+        ``image_height``/``image_width`` of ``0``), which would otherwise make the labels
+        impossible to decode or normalize. The first time this happens for a dataset, a warning
+        is emitted pointing at the offending Table.
+
+        :param im_file: The absolute path to the image file.
+        :return: The image dimensions as ``(height, width)``.
+        """
+        if not self._warned_missing_image_dimensions:
+            self._warned_missing_image_dimensions = True
+            LOGGER.warning(
+                f"{colorstr(self.prefix + ':')} Table {self.table.url.to_str()} contains annotations with "
+                "non-positive image dimensions. Falling back to reading the dimensions from the image files, "
+                "which is slower. This usually means the Table was created without valid image dimensions - "
+                "consider re-creating it so the dimensions are stored."
+            )
+        return ImageHelper.get_exif_image_dimensions(im_file)
 
     def _get_label_from_row(self, im_file: str, row: Any, example_id: int) -> Any:
         raise NotImplementedError("Subclasses must implement this method")

--- a/src/tlc_ultralytics/engine/dataset.py
+++ b/src/tlc_ultralytics/engine/dataset.py
@@ -62,7 +62,7 @@ class TLCDatasetMixin:
 
         return url.to_absolute(table_url).to_str()
 
-    def _resolve_image_dimensions(self, im_file: str, height: float, width: float) -> tuple[int, int]:
+    def _resolve_image_dimensions(self, im_file: str, height: float, width: float) -> tuple[float, float]:
         """Resolve the image ``(height, width)`` for a row.
 
         Annotations record their own image dimensions. When those are missing or non-positive

--- a/src/tlc_ultralytics/engine/dataset.py
+++ b/src/tlc_ultralytics/engine/dataset.py
@@ -62,26 +62,36 @@ class TLCDatasetMixin:
 
         return url.to_absolute(table_url).to_str()
 
-    def _resolve_image_dimensions(self, im_file: str) -> tuple[int, int]:
-        """Read the ``(height, width)`` of an image from disk.
+    def _resolve_image_dimensions(self, im_file: str, height: float, width: float) -> tuple[int, int]:
+        """Resolve the image ``(height, width)`` for a row.
 
-        Used as a fallback when a Table stores non-positive annotation dimensions (e.g. an
-        ``image_height``/``image_width`` of ``0``), which would otherwise make the labels
-        impossible to decode or normalize. The first time this happens for a dataset, a warning
-        is emitted pointing at the offending Table.
+        Annotations record their own image dimensions. When those are missing or non-positive
+        - which makes the labels impossible to decode or normalize - fall back to reading the
+        dimensions from the image file instead.
 
         :param im_file: The absolute path to the image file.
-        :return: The image dimensions as ``(height, width)``.
+        :param height: The image height recorded in the annotation (``<= 0`` if absent).
+        :param width: The image width recorded in the annotation (``<= 0`` if absent).
+        :return: The resolved image dimensions as ``(height, width)``.
         """
-        if not self._warned_missing_image_dimensions:
-            self._warned_missing_image_dimensions = True
-            LOGGER.warning(
-                f"{colorstr(self.prefix + ':')} Table {self.table.url.to_str()} contains annotations with "
-                "non-positive image dimensions. Falling back to reading the dimensions from the image files, "
-                "which is slower. This usually means the Table was created without valid image dimensions - "
-                "consider re-creating it so the dimensions are stored."
-            )
+        if height > 0 and width > 0:
+            return height, width
+
+        self._warn_missing_image_dimensions()
         return ImageHelper.get_exif_image_dimensions(im_file)
+
+    def _warn_missing_image_dimensions(self) -> None:
+        """Warn, once per dataset, that the Table stores annotations without valid image dimensions."""
+        if self._warned_missing_image_dimensions:
+            return
+
+        self._warned_missing_image_dimensions = True
+        LOGGER.warning(
+            f"{colorstr(self.prefix + ':')} Table {self.table.url.to_str()} contains annotations with "
+            "non-positive image dimensions. Falling back to reading the dimensions from the image files, "
+            "which is slower. This usually means the Table was created without valid image dimensions - "
+            "consider re-creating it so the dimensions are stored."
+        )
 
     def _get_label_from_row(self, im_file: str, row: Any, example_id: int) -> Any:
         raise NotImplementedError("Subclasses must implement this method")

--- a/src/tlc_ultralytics/obb/dataset.py
+++ b/src/tlc_ultralytics/obb/dataset.py
@@ -93,10 +93,16 @@ class TLCOBBDataset(BaseTLCYOLODataset):
         label_root = self._label_column_name.split(".")[0]
         instances = OrientedBoundingBoxes2D.from_row(row[label_root])
 
-        image_width = float(instances.x_max - (instances.x_min or 0))
-        image_height = float(instances.y_max - (instances.y_min or 0))
+        # The coordinate-space bounds carry the image dimensions; fall back to the real image
+        # size if they are missing or non-positive.
+        image_width = float(instances.x_max - (instances.x_min or 0)) if instances.x_max else 0.0
+        image_height = float(instances.y_max - (instances.y_min or 0)) if instances.y_max else 0.0
+        if image_width <= 0 or image_height <= 0:
+            image_height, image_width = self._resolve_image_dimensions(im_file)
 
-        cls_arr = instances.labels.astype(np.float32).reshape(-1, 1)
+        # Unlabeled rows come back with `labels=None`
+        labels = instances.labels if instances.labels is not None else np.zeros(0, dtype=np.float32)
+        cls_arr = labels.astype(np.float32).reshape(-1, 1)
 
         boxes = []
         segments = []

--- a/src/tlc_ultralytics/obb/dataset.py
+++ b/src/tlc_ultralytics/obb/dataset.py
@@ -97,8 +97,7 @@ class TLCOBBDataset(BaseTLCYOLODataset):
         # size if they are missing or non-positive.
         image_width = float(instances.x_max - (instances.x_min or 0)) if instances.x_max else 0.0
         image_height = float(instances.y_max - (instances.y_min or 0)) if instances.y_max else 0.0
-        if image_width <= 0 or image_height <= 0:
-            image_height, image_width = self._resolve_image_dimensions(im_file)
+        image_height, image_width = self._resolve_image_dimensions(im_file, image_height, image_width)
 
         # Unlabeled rows come back with `labels=None`
         labels = instances.labels if instances.labels is not None else np.zeros(0, dtype=np.float32)

--- a/src/tlc_ultralytics/pose/dataset.py
+++ b/src/tlc_ultralytics/pose/dataset.py
@@ -44,10 +44,15 @@ class TLCYOLOPoseDataset(BaseTLCYOLODataset):
         kpt_shape = self.data.get("kpt_shape")
         instances = tlc.data_types.Keypoints2D.from_row(label_column_value)
 
-        # Image dimensions and raw arrays
-        H = float(instances.y_max - (instances.y_min or 0))
-        W = float(instances.x_max - (instances.x_min or 0))
-        labels = instances.labels.astype(np.int32, copy=False)  # (N,)
+        # Image dimensions and raw arrays. The coordinate-space bounds carry the image
+        # dimensions; fall back to the real image size if they are missing or non-positive.
+        H = float(instances.y_max - (instances.y_min or 0)) if instances.y_max else 0.0
+        W = float(instances.x_max - (instances.x_min or 0)) if instances.x_max else 0.0
+        if H <= 0 or W <= 0:
+            H, W = self._resolve_image_dimensions(im_file)
+        # Unlabeled rows come back with `labels=None`
+        labels = instances.labels if instances.labels is not None else np.zeros(0, dtype=np.int32)
+        labels = labels.astype(np.int32, copy=False)  # (N,)
         bboxes_xyxy = instances.bounding_boxes.astype(np.float32, copy=False)  # (N,4) [x_min, y_min, x_max, y_max]
         kxy = instances.keypoints.astype(np.float32, copy=False)  # (N,K,2)
         vis = instances.keypoint_visibilities  # (N,K) ndarray; empty (0, 0) when no visibilities

--- a/src/tlc_ultralytics/pose/dataset.py
+++ b/src/tlc_ultralytics/pose/dataset.py
@@ -46,10 +46,9 @@ class TLCYOLOPoseDataset(BaseTLCYOLODataset):
 
         # Image dimensions and raw arrays. The coordinate-space bounds carry the image
         # dimensions; fall back to the real image size if they are missing or non-positive.
-        H = float(instances.y_max - (instances.y_min or 0)) if instances.y_max else 0.0
-        W = float(instances.x_max - (instances.x_min or 0)) if instances.x_max else 0.0
-        if H <= 0 or W <= 0:
-            H, W = self._resolve_image_dimensions(im_file)
+        image_height = float(instances.y_max - (instances.y_min or 0)) if instances.y_max else 0.0
+        image_width = float(instances.x_max - (instances.x_min or 0)) if instances.x_max else 0.0
+        image_height, image_width = self._resolve_image_dimensions(im_file, image_height, image_width)
         # Unlabeled rows come back with `labels=None`
         labels = instances.labels if instances.labels is not None else np.zeros(0, dtype=np.int32)
         labels = labels.astype(np.int32, copy=False)  # (N,)
@@ -58,15 +57,15 @@ class TLCYOLOPoseDataset(BaseTLCYOLODataset):
         vis = instances.keypoint_visibilities  # (N,K) ndarray; empty (0, 0) when no visibilities
 
         # Normalize keypoints to [0,1]
-        kxy[..., 0] /= W
-        kxy[..., 1] /= H
+        kxy[..., 0] /= image_width
+        kxy[..., 1] /= image_height
 
         # Vectorized: xyxy (abs) -> center-xywh (normalized)
         xy_min = bboxes_xyxy[:, 0:2]
         xy_max = bboxes_xyxy[:, 2:4]
         wh_abs = xy_max - xy_min
         ctr_abs = xy_min + 0.5 * wh_abs
-        scale = np.array([W, H], dtype=np.float32)
+        scale = np.array([image_width, image_height], dtype=np.float32)
         bboxes_arr = np.concatenate([(ctr_abs / scale), (wh_abs / scale)], axis=1).astype(np.float32)
 
         # Handle empty vs non-empty
@@ -88,7 +87,7 @@ class TLCYOLOPoseDataset(BaseTLCYOLODataset):
 
         return {
             "im_file": im_file,
-            "shape": (round(H), round(W)),
+            "shape": (round(image_height), round(image_width)),
             "cls": cls_arr,
             "bboxes": bboxes_arr,
             "segments": [],

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -746,6 +746,218 @@ def test_seg_table_checker() -> None:
         check_seg_table(invalid_schema_seg_table, "image", "segmentations")
 
 
+def _instance_task_config(task: str, width: int, height: int) -> dict:
+    """Per-task building blocks for constructing instance-task tables (detect/segment/obb/pose).
+
+    Returns the column name, schema, label path, dataset ``names``, extra ``data`` kwargs, the
+    annotation key to compare on, a labeled row, an unlabeled (empty) row, and copies of both with
+    their stored image dimensions zeroed out. The dimensions live in different fields per task:
+    segmentation stores ``image_height``/``image_width``, while the box/keypoint tasks carry them
+    as the coordinate-space bounds ``x_max``/``y_max`` (annotations are stored as absolute pixels).
+    """
+    from tlc.constants import IMAGE_HEIGHT, IMAGE_WIDTH, X_MAX, Y_MAX
+    from tlc.data_types import BoundingBoxes2D, Keypoints2D, OrientedBoundingBoxes2D, SegmentationPolygons
+
+    if task == "detect":
+        column = "bbs"
+        schema = BoundingBoxes2D.schema(classes={0: "object"})
+        labeled_row = BoundingBoxes2D(
+            bounding_boxes=[[width / 2, height / 2, width / 4, height / 4]],
+            bounding_box_format="cxywh",
+            image_width=width,
+            image_height=height,
+            labels=[0],
+        ).to_row()
+        empty_template = BoundingBoxes2D.create_empty(image_width=width, image_height=height).to_row()
+        label_container, label_path = "instances_additional_data", "bbs.instances_additional_data.label"
+        names, data_extra, compare_key = {0: "object"}, {}, "bboxes"
+        dim_zero = {X_MAX: 0.0, Y_MAX: 0.0}
+    elif task == "segment":
+        column = "segmentations"
+        schema = SegmentationPolygons.schema(classes={0: "object"})
+        labeled_row = SegmentationPolygons(
+            image_width=width,
+            image_height=height,
+            polygons=[[5.0, 5.0, 40.0, 5.0, 40.0, 30.0, 5.0, 30.0]],
+            labels=[0],
+        ).to_row()
+        empty_template = SegmentationPolygons.create_empty(image_width=width, image_height=height).to_row()
+        label_container, label_path = "instance_properties", "segmentations.instance_properties.label"
+        names, data_extra, compare_key = {0: "object"}, {}, "segments"
+        dim_zero = {IMAGE_HEIGHT: 0, IMAGE_WIDTH: 0}
+    elif task == "obb":
+        column = "obb"
+        schema = OrientedBoundingBoxes2D.schema(classes={0: "object"})
+        labeled_row = OrientedBoundingBoxes2D(
+            image_width=width,
+            image_height=height,
+            obbs=[[width / 2, height / 2, width / 4, height / 4, 0.0]],
+            labels=[0],
+        ).to_row()
+        empty_template = OrientedBoundingBoxes2D.create_empty(image_width=width, image_height=height).to_row()
+        label_container, label_path = "instances_additional_data", "obb.instances_additional_data.label"
+        names, data_extra, compare_key = {0: "object"}, {}, "segments"
+        dim_zero = {X_MAX: 0.0, Y_MAX: 0.0}
+    elif task == "pose":
+        column = "pose"
+        schema = Keypoints2D.schema(num_keypoints=2, classes={0: "person"})
+        labeled_row = Keypoints2D(
+            image_width=width,
+            image_height=height,
+            keypoints=[[[10, 10], [20, 20]]],
+            keypoint_visibilities=[[2, 2]],
+            bounding_boxes=[[5, 5, 25, 25]],
+            labels=[0],
+        ).to_row()
+        empty_template = Keypoints2D.create_empty(image_width=width, image_height=height).to_row()
+        label_container, label_path = "instances_additional_data", "pose.instances_additional_data.label"
+        names, data_extra, compare_key = {0: "person"}, {"kpt_shape": [2, 3]}, "keypoints"
+        dim_zero = {X_MAX: 0.0, Y_MAX: 0.0}
+    else:
+        raise ValueError(f"Unknown task: {task}")
+
+    # A real table writer fills the label sub-column with an empty list for unlabeled rows
+    # (rather than the bare ``{}`` that ``create_empty().to_row()`` produces), so mirror that here
+    # to keep the column schema consistent across rows.
+    empty_row = {**empty_template, label_container: {"label": []}}
+
+    return {
+        "column": column,
+        "schema": schema,
+        "label_path": label_path,
+        "names": names,
+        "data_extra": data_extra,
+        "compare_key": compare_key,
+        "labeled_row": labeled_row,
+        "empty_row": empty_row,
+        "zeroed_row": {**labeled_row, **dim_zero},
+        "empty_zeroed_row": {**empty_row, **dim_zero},
+    }
+
+
+def _build_task_dataset(task: str, config: dict, rows: list[dict], table_name: str):
+    """Build a 3LC YOLO dataset for ``task`` from a single-column table of ``rows``."""
+    from ultralytics.cfg import get_cfg
+    from ultralytics.utils import DEFAULT_CFG
+
+    from tlc_ultralytics.detect.utils import build_tlc_yolo_dataset
+
+    # Labeled row is passed first by callers so the column schema is inferred from a fully
+    # populated row.
+    table = tlc.Table.from_dict(
+        {"image": [str(DUMMY_IMAGE_FILE)] * len(rows), config["column"]: rows},
+        schema={config["column"]: config["schema"]},
+        project_name="test_instance_tasks",
+        dataset_name=task,
+        table_name=table_name,
+        if_exists="overwrite",
+    )
+    cfg = get_cfg(DEFAULT_CFG, overrides={"task": task, "imgsz": 64, "rect": False})
+    return build_tlc_yolo_dataset(
+        cfg,
+        table,
+        batch=1,
+        data={"channels": 3, "names": config["names"], "nc": 1, **config["data_extra"]},
+        mode="val",
+        image_column_name="image",
+        label_column_name=config["label_path"],
+    )
+
+
+@pytest.mark.parametrize("task", ["detect", "segment", "obb", "pose"])
+def test_missing_image_dimensions_fallback(task: str) -> None:
+    """A Table that stores non-positive image dimensions must not crash. The dataset should fall
+    back to reading the real image size from disk, recover the annotations against that size, and
+    warn once. Regression test for tables authored without valid image dimensions.
+    """
+    from tlc.helpers import ImageHelper
+
+    # Real image on disk; annotations are encoded against its true size.
+    height, width = ImageHelper.get_exif_image_dimensions(str(DUMMY_IMAGE_FILE))
+    config = _instance_task_config(task, width, height)
+
+    # Reference dataset: correct dimensions stored.
+    reference = _build_task_dataset(task, config, [config["labeled_row"]], "dims_good")
+
+    # Broken dataset: image dimensions zeroed out (valid annotations, but no usable size metadata).
+    with capture_logs(logging.WARNING) as log_messages:
+        recovered = _build_task_dataset(task, config, [config["zeroed_row"]], "dims_zeroed")
+
+    # The fallback warned about the missing dimensions...
+    assert any("non-positive image dimensions" in msg for msg in log_messages), (
+        f"Expected a warning about missing image dimensions, got: {log_messages}"
+    )
+
+    ref_label, got_label = reference.labels[0], recovered.labels[0]
+
+    # ...recovered the real image shape...
+    assert got_label["shape"] == (height, width) == ref_label["shape"]
+
+    # ...and reconstructed identical, normalized ([0, 1]) annotations against that size.
+    ref_val, got_val = ref_label[config["compare_key"]], got_label[config["compare_key"]]
+    pairs = zip(ref_val, got_val, strict=True) if isinstance(ref_val, list) else [(ref_val, got_val)]
+    if isinstance(ref_val, list):
+        assert len(got_val) == len(ref_val) >= 1
+    for ref_arr, got_arr in pairs:
+        np.testing.assert_allclose(got_arr, ref_arr, atol=1e-6)
+        assert np.max(got_arr) <= 1.0 + 1e-6
+    # The normalized boxes are also recovered identically for every task.
+    np.testing.assert_allclose(got_label["bboxes"], ref_label["bboxes"], atol=1e-6)
+
+
+@pytest.mark.parametrize("task", ["detect", "segment", "obb", "pose"])
+def test_unlabeled_row(task: str) -> None:
+    """An unlabeled row (no instances) must not crash. The instance dataclasses come back with
+    ``labels=None`` for an empty row, which previously raised ``TypeError: 'NoneType' object is
+    not iterable`` (segment) or ``AttributeError: 'NoneType' object has no attribute 'astype'``
+    (obb/pose). The dataset should instead produce a label with zero instances. Regression test
+    for training on revision tables that still have some unlabeled samples.
+    """
+    from tlc.helpers import ImageHelper
+
+    height, width = ImageHelper.get_exif_image_dimensions(str(DUMMY_IMAGE_FILE))
+    config = _instance_task_config(task, width, height)
+
+    dataset = _build_task_dataset(task, config, [config["labeled_row"], config["empty_row"]], "unlabeled")
+
+    # The unlabeled row yields zero instances; the labeled row is unaffected.
+    labeled_label, empty_label = dataset.labels[0], dataset.labels[1]
+    assert empty_label["cls"].shape == (0, 1)
+    assert empty_label["bboxes"].shape == (0, 4)
+    assert empty_label["shape"] == (height, width)
+    assert labeled_label["cls"].shape == (1, 1)
+    if task == "segment":
+        assert empty_label["segments"] == []
+    elif task == "pose":
+        assert empty_label["keypoints"].shape == (0, 2, 3)
+
+
+@pytest.mark.parametrize("task", ["detect", "segment", "obb", "pose"])
+def test_unlabeled_row_with_missing_dimensions(task: str) -> None:
+    """The realistic revision-table case: a row that is both unlabeled *and* has non-positive
+    image dimensions - exactly what ``create_empty()`` produces by default. The dimension fallback
+    and the empty-label handling must compose, so the row decodes to zero instances at the real
+    image size and warns once.
+    """
+    from tlc.helpers import ImageHelper
+
+    height, width = ImageHelper.get_exif_image_dimensions(str(DUMMY_IMAGE_FILE))
+    config = _instance_task_config(task, width, height)
+
+    with capture_logs(logging.WARNING) as log_messages:
+        dataset = _build_task_dataset(
+            task, config, [config["labeled_row"], config["empty_zeroed_row"]], "unlabeled_zeroed"
+        )
+
+    assert any("non-positive image dimensions" in msg for msg in log_messages), (
+        f"Expected a warning about missing image dimensions, got: {log_messages}"
+    )
+    empty_label = dataset.labels[1]
+    assert empty_label["cls"].shape == (0, 1)
+    assert empty_label["bboxes"].shape == (0, 4)
+    assert empty_label["shape"] == (height, width)
+
+
 def test_legacy_bb_table_default_label_path() -> None:
     # A legacy-format (bb_list) detection table should work with the default label column
     # name, which points at the new-format path (bbs.instances_additional_data.label).


### PR DESCRIPTION
Add fallback to use image size when annotation column doesn't provide it across instance tasks. Always handle unlabeled rows without erroring. Warn once when annotation column doesn't provide the image dimensions.