### PR TITLE
Bound memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 ### Added
 
-- Bound peak host memory during metrics collection by flushing to new metrics tables whenever the in-memory buffer exceeds the new `metrics_max_buffer_mb` setting (default 2048).
+- Bound peak host memory during metrics collection by flushing to new metrics tables whenever the in-memory buffer exceeds the new `metrics_max_buffer_mb` setting (default 256).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 ## [Unreleased]
 
+### Added
+
+- Bound peak host memory during metrics collection by flushing to new metrics tables whenever the in-memory buffer exceeds the new `metrics_max_buffer_mb` setting (default 2048).
+
+### Changed
+
+- Reduce image and instance embeddings natively in the integration, on at most `image_embeddings_fit_sample_size` images and `instance_embeddings_fit_sample_size` instances (new settings, default 10000) respectively. This bounds the memory and runtime of the fit on large datasets.
+
+- Transform image and instance embeddings on each metrics table at a time, rather than on all of the data for a split at once. This reduces the memory footprint of the transform calls on large datasets.
+
 ## [0.3.4] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 - Transform image and instance embeddings on each metrics table at a time, rather than on all of the data for a split at once. This reduces the memory footprint of the transform calls on large datasets.
 
+- `image_embeddings_reducer_args` now takes raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or `sklearn.decomposition.PCA`), matching `instance_embeddings_reducer_kwargs`, instead of 3LC reduction-table args (`PaCMAPTableArgs`/`UMAPTableArgs`). Keys specific to the table args (e.g. `retain_source_embedding_column`) are no longer accepted and will raise a `TypeError` from the reducer constructor. A user-supplied `n_components` is ignored in favor of `image_embeddings_dim` and `instance_embeddings_dim`.
+
 ## [0.3.4] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -256,7 +256,9 @@ The way in which embeddings are collected is different for the different tasks:
 - **Classification**: The integration scans your model for the first occurrence of a `torch.nn.Linear` layer. The inputs to this layer are used to extract image embeddings.
 - **Object Detection and Instance Segmentation**: The output of the spatial pooling function is used to extract embeddings.
 
-You can change which `3lc`-supported reducer to use by setting `image_embeddings_reducer`. `pacmap` is the default.
+Choose the reduction algorithm with `image_embeddings_reducer` (`pacmap`, `umap` or `pca`; `pacmap` is the default) and pass arguments to its constructor via `image_embeddings_reducer_args`. The reducer is fitted on a uniform random sample of at most `image_embeddings_fit_sample_size` images (default 10000) and all images are projected into the fitted space, so memory and fit time stay bounded on large datasets.
+
+> **Experimental:** image embeddings are currently reduced in-process by the integration. This will move to a native 3LC interface in the future, at which point some of these settings may change.
 
 ### Instance Embeddings
 
@@ -266,11 +268,9 @@ By default embeddings are extracted from the classification branch of the detect
 
 Instance embeddings have been tested with the YOLOv8, YOLO11 and YOLO26 detection heads. YOLO11 and YOLO26 use the classification branch directly; for YOLOv8 the integration automatically falls back to a neck layer. Other architectures are not guaranteed to be supported and may require setting `instance_embeddings_layer` explicitly.
 
-Choose the reduction algorithm with `instance_embeddings_reducer` (`pacmap`, `umap` or `pca`) and pass arguments to its constructor via `instance_embeddings_reducer_kwargs`.
+Choose the reduction algorithm with `instance_embeddings_reducer` (`pacmap`, `umap` or `pca`) and pass arguments to its constructor via `instance_embeddings_reducer_kwargs`. The reducer is fitted on a uniform random sample of at most `instance_embeddings_fit_sample_size` instances (default 10000) and all instances are projected into the fitted space, so memory and fit time stay bounded on large datasets.
 
 > **Experimental:** instance embeddings are currently reduced in-process by the integration. This will move to a native 3LC interface in the future, at which point some of these settings may change.
-
-> **Memory:** Instance embeddings holds the full feature vector for each instance — so on large datasets or with many detections it can use a lot of memory (tens of GB at full-COCO scale). To reduce it, collect on a smaller split, lower `max_det`, or raise `conf_thres`. A memory-bounded reduction path is planned.
 
 ### Run Properties
 
@@ -289,6 +289,7 @@ Use `exclude_zero_weight_training=True` (only applies to training) and `exclude_
 - **`collection_val_only=True`**: Disable metrics collection on the training set. This only applies to training.
 - **`collection_disable=True`**: Disable metrics collection entirely. This only applies to training. A run will still be created, and hyperparameters and aggregate metrics will be logged to 3LC.
 - **`collection_epoch_start` and `collection_epoch_interval`**: Define when to collect metrics during training. The start epoch is 1-based, i.e. 1 means after the first epoch. As an example, `collection_epoch_start=1` with `collection_epoch_interval=2` means metrics collection will occur after the first epoch and then every other epoch after that.
+- **`metrics_max_buffer_mb`**: Maximum size in MB of metrics buffered in memory before they are flushed to a metrics table and a new one is started (default 2048). Peak host memory during collection stays bounded regardless of dataset size; the flushed tables are joined back together in the 3LC Dashboard. Lower this when collecting heavy per-row metrics (segmentation masks, instance embeddings) on machines with limited memory.
 
 ### Column names
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Use `exclude_zero_weight_training=True` (only applies to training) and `exclude_
 - **`collection_val_only=True`**: Disable metrics collection on the training set. This only applies to training.
 - **`collection_disable=True`**: Disable metrics collection entirely. This only applies to training. A run will still be created, and hyperparameters and aggregate metrics will be logged to 3LC.
 - **`collection_epoch_start` and `collection_epoch_interval`**: Define when to collect metrics during training. The start epoch is 1-based, i.e. 1 means after the first epoch. As an example, `collection_epoch_start=1` with `collection_epoch_interval=2` means metrics collection will occur after the first epoch and then every other epoch after that.
-- **`metrics_max_buffer_mb`**: Maximum size in MB of metrics buffered in memory before they are flushed to a metrics table and a new one is started (default 2048). Peak host memory during collection stays bounded regardless of dataset size; the flushed tables are joined back together in the 3LC Dashboard. Lower this when collecting heavy per-row metrics (segmentation masks, instance embeddings) on machines with limited memory.
+- **`metrics_max_buffer_mb`**: Maximum size in MB of metrics buffered in memory before they are flushed to a metrics table and a new one is started (default 256). This keeps the metrics buffer from growing with dataset size; the flushed tables are joined back together in the 3LC Dashboard. Lower this when collecting heavy per-row metrics (segmentation masks, instance embeddings) on machines with limited memory.
 
 ### Column names
 

--- a/src/tlc_ultralytics/detect/validator.py
+++ b/src/tlc_ultralytics/detect/validator.py
@@ -52,8 +52,8 @@ class TLCDetectionValidator(TLCValidatorMixin, DetectionValidator):
         bbox_schema = yolo_predicted_bounding_box_schema(self.data["names_3lc"])
 
         # Instance-embedding columns (raw + reduced) are added by the mixin in
-        # _pre_validation / _fit_and_rewrite — task validators only contribute
-        # task-specific schemas here.
+        # _pre_validation / _reduce_and_rewrite_raw_tables — task validators only
+        # contribute task-specific schemas here.
         return {
             PREDICTED_BOUNDING_BOXES: bbox_schema,
             **loss_schemas,

--- a/src/tlc_ultralytics/engine/model.py
+++ b/src/tlc_ultralytics/engine/model.py
@@ -20,7 +20,7 @@ from tlc_ultralytics.obb import TLCOBBTrainer, TLCOBBValidator
 from tlc_ultralytics.pose import TLCPoseTrainer, TLCPoseValidator
 from tlc_ultralytics.segment import TLCSegmentationTrainer, TLCSegmentationValidator
 from tlc_ultralytics.settings import Settings
-from tlc_ultralytics.utils import check_requirements, reduce_embeddings
+from tlc_ultralytics.utils import check_requirements
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -93,7 +93,7 @@ class YOLO(YOLOBase):
             },
         }
 
-    def collect( # noqa: C901
+    def collect(
         self,
         data: str | None = None,
         splits: Iterable[str] | None = None,
@@ -104,10 +104,9 @@ class YOLO(YOLOBase):
     ) -> dict[str, dict[str, float]]:
         """Perform calls to model.val() to collect metrics on a set of splits, all under one tlc.Run.
 
-        If enabled, embeddings are reduced at the end of validation. When instance
-        embeddings are enabled and multiple splits are collected, the first split
-        (train) defines the reduction space and subsequent splits are projected
-        into it.
+        If enabled, embeddings are reduced at the end of each split's validation
+        pass. When multiple splits are collected, the first split (train) defines
+        the reduction spaces and subsequent splits are projected into them.
 
         :param data: Path to a YOLO or 3LC YAML file. If provided, splits must also be provided.
         :param splits: List of splits to collect metrics for. If provided, data must also be provided.
@@ -164,37 +163,20 @@ class YOLO(YOLOBase):
                 if progress_callback:
                     progress_callback("split_start", 0, 0)
                 results_dict[split] = self.val(settings=settings, **split_val_kwargs[split], **kwargs)
-
-            if settings.image_embeddings_dim > 0:
-                self._reduce_image_embeddings(settings, progress_callback)
         finally:
-            # TEMP(instance-embeddings): drop this run's fitted reducer (also on
+            # TEMP(embeddings): drop this run's fitted reducers (also on
             # failure — a later collect() may reuse the same active run and must
             # not inherit a stale embedding space).
-            if settings.instance_embeddings_dim > 0 and tlc.active_run() is not None:
-                from tlc_ultralytics.utils._instance_reduce import _clear_fitted_reducer
+            if (
+                settings.instance_embeddings_dim > 0 or settings.image_embeddings_dim > 0
+            ) and tlc.active_run() is not None:
+                from tlc_ultralytics.utils._instance_reduce import _clear_fitted_reducers
 
-                _clear_fitted_reducer(tlc.active_run().url.to_str())
+                _clear_fitted_reducers(tlc.active_run().url.to_str())
 
         tlc.active_run().set_status_completed()
 
         return results_dict
-
-    @staticmethod
-    def _reduce_image_embeddings(settings: Settings, progress_callback: object | None) -> None:
-        """Reduce image embeddings server-side across all collected splits."""
-        if progress_callback:
-            progress_callback("image_embeddings", 0, 0)
-
-        reduce_embeddings(
-            tlc.active_run(),
-            method=settings.image_embeddings_reducer,
-            n_components=settings.image_embeddings_dim,
-            reducer_args=settings.image_embeddings_reducer_args,
-        )
-
-        if progress_callback:
-            progress_callback("image_embeddings_done", 0, 0)
 
 
 class TLCYOLO(YOLO):

--- a/src/tlc_ultralytics/engine/trainer.py
+++ b/src/tlc_ultralytics/engine/trainer.py
@@ -21,7 +21,7 @@ from tlc_ultralytics.engine.utils import (
 )
 from tlc_ultralytics.overrides import build_dataloader
 from tlc_ultralytics.settings import Settings
-from tlc_ultralytics.utils import create_sampler, reduce_embeddings
+from tlc_ultralytics.utils import create_sampler
 from tlc_ultralytics.utils.dataset import check_tlc_dataset
 from tlc_ultralytics.utils.generate_ddp import generate_ddp_command
 
@@ -323,18 +323,15 @@ class TLCTrainerMixin(BaseTrainer):
 
         if RANK in {-1, 0}:
             self._save_confidence_metrics()
-            if self._settings.image_embeddings_dim > 0:
-                train_url = self.data["train"].url
-                val_url = self.data["val"].url if "val" in self.data else self.data["test"].url
-                foreign_table_url = train_url if not self._settings.collection_val_only else val_url
-                reduce_embeddings(
-                    self._run,
-                    method=self._settings.image_embeddings_reducer,
-                    n_components=self._settings.image_embeddings_dim,
-                    foreign_table_url=foreign_table_url,
-                    reducer_args=self._settings.image_embeddings_reducer_args,
-                )
             self._run.set_status_completed()
+
+            # TEMP(embeddings): embeddings are reduced per validation pass in the
+            # validator; drop this run's fitted reducers now that the run is done
+            # so a later run cannot inherit a stale embedding space.
+            if self._settings.instance_embeddings_dim > 0 or self._settings.image_embeddings_dim > 0:
+                from tlc_ultralytics.utils._instance_reduce import _clear_fitted_reducers
+
+                _clear_fitted_reducers(self._run.url.to_str())
 
     def _save_confidence_metrics(self):
         if self.args.task not in ("detect", "segment", "pose", "obb"):

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -39,7 +39,12 @@ from tlc_ultralytics.constants import (
 from tlc_ultralytics.engine.utils import _handle_deprecated_column_name
 from tlc_ultralytics.settings import Settings
 from tlc_ultralytics.utils import image_embeddings_schema, training_phase_schema
-from tlc_ultralytics.utils.schemas import _instance_embeddings_list_schema, _raw_instance_embeddings_schema
+from tlc_ultralytics.utils._rolling_writer import _RollingMetricsWriter
+from tlc_ultralytics.utils.schemas import (
+    _instance_embeddings_list_schema,
+    _raw_instance_embeddings_schema,
+    _reduced_image_embeddings_schema,
+)
 
 
 def execute_when_collecting(method):
@@ -95,12 +100,13 @@ class TLCValidatorMixin(BaseValidator):
 
         # TEMP(instance-embeddings): the cls-head hook stashes its captured feature
         # map here every forward pass; raw embeddings are extracted from it during
-        # _update_metrics and discarded once written. The two `_raw_*_emb` lists
-        # accumulate every instance's raw vector for the whole validation pass so
-        # the reducer can fit on them at the end.
+        # _update_metrics, written inline to the metrics tables, and discarded.
+        # The reducer is fitted at end of pass from a sample read back from those
+        # tables; _pred_instances_per_table tracks how many predicted instances
+        # each flushed table holds so the sample can be allocated across tables
+        # without re-reading them.
         self._instance_feature_map = None
-        self._raw_pred_emb: list[np.ndarray] = []
-        self._raw_gt_emb: list[np.ndarray] = []
+        self._pred_instances_per_table: list[int] = []
 
         # Per-batch caches so _prepare_batch and _filter_top_predictions run once per image, shared by annotation
         # building and instance-embedding extraction.
@@ -524,14 +530,14 @@ class TLCValidatorMixin(BaseValidator):
         In DDP mode, each rank collects metrics for its portion of the data.
         These are gathered to RANK 0 in _post_validation.
 
-        When instance_embeddings_dim > 0, raw per-instance embeddings are
-        written inline as ``predicted_instance_embedding_raw`` / ``..._raw_gt``
-        and also accumulated in an in-RAM list for fitting the reducer at
-        end-of-pass. That list is unbounded: it grows with the total number of
-        predicted instances and can reach tens of GB at full-COCO scale (a
-        memory-bounded path is planned). The streaming write of heavy fields
-        like RLE masks via ``MetricsTableWriter.add_batch`` is bounded; the raw
-        embedding accumulation is not.
+        All metrics stream through a rolling writer that flushes to a new
+        metrics table whenever its in-memory buffer exceeds
+        ``Settings.metrics_max_buffer_mb``, so peak host memory is bounded
+        regardless of dataset size. When instance_embeddings_dim > 0, raw
+        per-instance embeddings are written inline as
+        ``predicted_instance_embedding_raw`` / ``ground_truth_..._raw`` columns
+        and reduced from the written tables at end of pass — nothing
+        accumulates in RAM here.
         """
         batch_size = self._infer_batch_size(preds, batch)
 
@@ -567,14 +573,19 @@ class TLCValidatorMixin(BaseValidator):
             batch_metrics[PREDICTED_INSTANCE_EMBEDDING_RAW] = [
                 (a.tolist() if a.size else []) for a in raw_instance_embs
             ]
-            self._raw_pred_emb.extend(raw_instance_embs)
+
+            # Count predicted instances per destination table for the end-of-pass reducer-fit
+            # sampling. Read the table index before add_batch — the writer may roll inside it.
+            table_index = self._metrics_writer.num_flushed_tables
+            while len(self._pred_instances_per_table) <= table_index:
+                self._pred_instances_per_table.append(0)
+            self._pred_instances_per_table[table_index] += sum(a.shape[0] for a in raw_instance_embs)
 
             if self._settings.ground_truth_instance_embeddings:
                 raw_gt_embs = self._extract_gt_instance_embeddings(preds, batch)
                 batch_metrics[GROUND_TRUTH_INSTANCE_EMBEDDING_RAW] = [
                     (a.tolist() if a.size else []) for a in raw_gt_embs
                 ]
-                self._raw_gt_emb.extend(raw_gt_embs)
 
         self._metrics_writer.add_batch(batch_metrics)
         self._seen += batch_size
@@ -615,8 +626,6 @@ class TLCValidatorMixin(BaseValidator):
                 column_schemas[GROUND_TRUTH_INSTANCE_EMBEDDING_RAW] = _raw_instance_embeddings_schema(
                     c_raw, display_name="Ground Truth Instance Embedding (raw)"
                 )
-            self._raw_pred_emb = []
-            self._raw_gt_emb = []
 
         if self._epoch is not None:
             column_schemas[TRAINING_PHASE] = training_phase_schema()
@@ -633,76 +642,67 @@ class TLCValidatorMixin(BaseValidator):
         if RANK in {-1, 0}:
             self._run.set_status_collecting()
 
-        self._metrics_writer = tlc.MetricsTableWriter(
+        # Rolling writer: flushes to a new metrics table whenever the in-memory buffer
+        # exceeds the configured threshold, bounding peak host memory during collection.
+        # The flushed tables share a stream and are joined in the Dashboard.
+        self._metrics_writer = _RollingMetricsWriter(
             run_url=self._run.url,
             foreign_table_url=self.dataloader.dataset.table.url,
             schema=column_schemas,
+            max_buffer_bytes=self._settings.metrics_max_buffer_mb * 1024 * 1024,
         )
 
+        self._pred_instances_per_table = []
         self._seen = 0
 
     @execute_when_collecting
     def _post_validation(self):
         """Clean up the validator after one validation pass.
 
-        Finalizes the streaming metrics writer. When instance_embeddings_dim > 0,
-        fits a reducer on the accumulated raw embeddings and rewrites the metrics
-        table, replacing the raw embedding columns with reduced ones; the raw
-        table is then deleted from disk and the reduced table is registered on
-        the run. In DDP mode, gathers metrics_infos and input table URLs from
-        all ranks to RANK 0, which then updates the run.
+        Finalizes the rolling metrics writer, which may have flushed several
+        tables during the pass. When instance or image embeddings are enabled,
+        reducers are fitted on bounded samples of raw embeddings read back from
+        the flushed tables, and each table is rewritten one at a time with the
+        raw embedding columns replaced by reduced ones; the raw tables are then
+        deleted from disk. In DDP mode, table urls and metrics infos are
+        gathered from all ranks to RANK 0, which performs the reduction/rewrite
+        for every rank's tables (they live on shared storage) and updates the
+        run.
         """
-        # Each rank finalizes its streaming writer. As of tlc 3.x, finalize()
-        # also registers the written table on the run (the later
+        # Each rank finalizes its rolling writer. Flushed tables were already
+        # registered on the run as they were written (the later
         # run.update_metrics call below deduplicates).
-        raw_table = self._metrics_writer.finalize()
-        metrics_infos = self._metrics_writer.get_written_metrics_infos()
+        table_urls, metrics_infos = self._metrics_writer.finalize()
+        table_url_strs = [url.to_str() for url in table_urls]
+        pred_instance_counts = list(self._pred_instances_per_table)
+        pred_instance_counts += [0] * (len(table_url_strs) - len(pred_instance_counts))
         input_table_url = self.dataloader.dataset.table.url.to_str()
 
-        # TEMP(instance-embeddings): reduce the raw embeddings and rewrite the
-        # just-finalized raw table into a reduced one, then delete the raw
-        # table on disk. Under DDP the reducer is fitted once on RANK 0 from
-        # all ranks' gathered embeddings (see
-        # _compute_reduced_instance_embeddings), so the reduced spaces are
-        # shared across ranks; each rank rewrites its own table.
-        if self._settings.instance_embeddings_dim > 0:
-            raw_metrics_infos = metrics_infos
-            _, reduced_metrics_infos = self._fit_and_rewrite(raw_table)
-            # finalize() registered the raw table on the run; remove that
-            # registration and the table itself on disk so the run doesn't
-            # reference a deleted table.
-            self._remove_metrics_infos_from_run(raw_metrics_infos)
-            self._delete_table_on_disk(raw_table)
-            metrics_infos = reduced_metrics_infos
+        # Gather every rank's table urls and metrics infos to RANK 0 in DDP mode
+        table_url_strs, metrics_infos, pred_instance_counts, input_table_urls = self._gather_written_tables(
+            table_url_strs, metrics_infos, pred_instance_counts, input_table_url
+        )
 
-        # Gather metrics from all ranks to RANK 0 in DDP mode
-        input_table_urls: list[str] = []
-        if RANK >= 0:
-            world_size = dist.get_world_size()  # type: ignore[possibly-missing-attribute]
-            gathered_metrics_infos = [None] * world_size if RANK == 0 else None
-            gathered_input_urls = [None] * world_size if RANK == 0 else None
-
-            dist.gather_object(metrics_infos, gathered_metrics_infos, dst=0)  # type: ignore[possibly-missing-attribute]
-            dist.gather_object(input_table_url, gathered_input_urls, dst=0)  # type: ignore[possibly-missing-attribute]
-
-            if RANK == 0:
-                assert gathered_metrics_infos is not None
-                assert gathered_input_urls is not None
-
-                # Flatten metrics_infos from all ranks
-                all_metrics_infos = []
-                for rank_metrics in gathered_metrics_infos:
-                    all_metrics_infos.extend(rank_metrics)
-                metrics_infos = all_metrics_infos
-
-                # Collect unique input table URLs (should all be the same in distributed validation)
-                input_table_urls = list(set(gathered_input_urls))
-        else:
-            # Single GPU mode (RANK == -1)
-            input_table_urls = [input_table_url]
-
-        # Only RANK 0 (or single GPU) updates the run
+        # Only RANK 0 (or single GPU) reduces embeddings and updates the run
         if RANK in {-1, 0}:
+            # TEMP(embeddings): reduce the raw instance/image embeddings and
+            # rewrite each just-finalized raw table into a reduced one, then
+            # delete the raw tables on disk. Under DDP, RANK 0 rewrites all
+            # ranks' tables.
+            if self._settings.instance_embeddings_dim > 0 or self._settings.image_embeddings_dim > 0:
+                row_counts = [info["row_count"] for info in metrics_infos]
+                reduced_metrics_infos = self._reduce_and_rewrite_raw_tables(
+                    table_url_strs, pred_instance_counts, row_counts
+                )
+                if reduced_metrics_infos is not None:
+                    # Flushing registered the raw tables on the run; remove those
+                    # registrations and the tables themselves on disk so the run
+                    # doesn't reference deleted tables.
+                    self._remove_metrics_infos_from_run(metrics_infos)
+                    for url_str in table_url_strs:
+                        self._delete_table_on_disk(tlc.Url(url_str))
+                    metrics_infos = reduced_metrics_infos
+
             self._run.update_metrics(metrics_infos)
 
             for url in input_table_urls:
@@ -725,216 +725,298 @@ class TLCValidatorMixin(BaseValidator):
         self._training_phase = None
         self._final_validation = None
         self._instance_feature_map = None
-        self._raw_pred_emb = []
-        self._raw_gt_emb = []
-
-    def _reduce_raw_instance_embeddings(self, raw_pred, raw_gt):
-        """TEMP(instance-embeddings): reduce raw per-image embedding lists in-process.
-
-        Fits the configured reducer on the predicted embeddings (or reuses the
-        run's cross-split reducer if an earlier split already fitted one) and
-        projects ground-truth embeddings into the same space.
-
-        Returns (pred_reduced, gt_reduced), where gt_reduced is None when GT
-        embeddings are not collected.
-        """
-        from tlc_ultralytics.utils._instance_reduce import (
-            _get_fitted_reducer,
-            _reduce_instance_embeddings,
-            _set_fitted_reducer,
-            _transform_instance_embeddings,
-        )
-
-        n = self._settings.instance_embeddings_dim
-        method = self._settings.instance_embeddings_reducer
-        reducer_kwargs = self._settings.instance_embeddings_reducer_kwargs or {}
-        progress_cb = getattr(self._settings, "_reduction_progress_callback", None)
-        existing_reducer = _get_fitted_reducer(self._run.url.to_str())
-
-        if existing_reducer is not None:
-            pred_reduced = _transform_instance_embeddings(
-                raw_pred,
-                existing_reducer,
-                n_components=n,
-                progress_callback=progress_cb,
-                label="predicted",
-            )
-            reducer = existing_reducer
-        else:
-            pred_reduced, reducer = _reduce_instance_embeddings(
-                raw_pred,
-                method=method,
-                n_components=n,
-                progress_callback=progress_cb,
-                **reducer_kwargs,
-            )
-            if reducer is not None:
-                _set_fitted_reducer(self._run.url.to_str(), reducer)
-            else:
-                msg = (
-                    "No predicted instances were available to fit the instance-embeddings reducer "
-                    f"for this split (conf_thres={self._settings.conf_thres}); instance embeddings "
-                    "will be empty."
-                )
-                if self._settings.ground_truth_instance_embeddings and raw_gt:
-                    msg += " Ground-truth instance embeddings will be empty too."
-                LOGGER.warning(f"{TLC_COLORSTR}{msg}")
-
-        if self._settings.ground_truth_instance_embeddings and raw_gt:
-            if reducer is not None:
-                gt_reduced = _transform_instance_embeddings(
-                    raw_gt,
-                    reducer,
-                    n_components=n,
-                    progress_callback=progress_cb,
-                    label="ground-truth",
-                )
-            else:
-                gt_reduced = [np.empty((0, n), dtype=np.float32) for _ in raw_gt]
-        else:
-            gt_reduced = None
-
-        return pred_reduced, gt_reduced
-
-    def _compute_reduced_instance_embeddings(self):
-        """TEMP(instance-embeddings): reduce this rank's accumulated raw embeddings.
-
-        Single-process: fit/transform locally. Under DDP, raw embeddings from
-        all ranks are gathered to RANK 0, which fits a single reducer (or
-        reuses the cross-split one), transforms every rank's embeddings into
-        the one shared space, and scatters each rank its reduced share. The
-        fitted reducer stays on RANK 0 only (it is not broadcast — fitted
-        PaCMAP reducers are not picklable), which is sufficient since later
-        splits gather to RANK 0 again.
-        """
-        if RANK < 0:
-            return self._reduce_raw_instance_embeddings(self._raw_pred_emb, self._raw_gt_emb)
-
-        # DDP: gather per-rank raw embeddings to RANK 0
-        world_size = dist.get_world_size()  # type: ignore[possibly-missing-attribute]
-        # gather_object fills this in place on RANK 0 with each rank's
-        # (raw_pred, raw_gt) payload; annotate so the post-gather element type is known.
-        gathered: list[tuple[list[np.ndarray], list[np.ndarray]]] | None = [None] * world_size if RANK == 0 else None
-        dist.gather_object((self._raw_pred_emb, self._raw_gt_emb), gathered, dst=0)  # type: ignore[possibly-missing-attribute]
-
-        per_rank_reduced = None
-        if RANK == 0:
-            assert gathered is not None
-            all_pred = [arr for rank_pred, _ in gathered for arr in rank_pred]
-            all_gt = [arr for _, rank_gt in gathered for arr in rank_gt]
-            pred_reduced_all, gt_reduced_all = self._reduce_raw_instance_embeddings(all_pred, all_gt)
-            per_rank_reduced = self._split_reduced_by_rank(gathered, pred_reduced_all, gt_reduced_all)
-
-        output = [None]
-        dist.scatter_object_list(output, per_rank_reduced, src=0)  # type: ignore[possibly-missing-attribute]
-        return output[0]
+        self._pred_instances_per_table = []
 
     @staticmethod
-    def _split_reduced_by_rank(gathered, pred_reduced_all, gt_reduced_all):
-        """Re-split flattened reduced per-image lists by each rank's image count.
+    def _gather_written_tables(table_url_strs, metrics_infos, pred_instance_counts, input_table_url):
+        """Gather every rank's written-table urls, metrics infos and instance counts to RANK 0.
 
-        ``gathered`` is the list of (raw_pred, raw_gt) per-rank payloads whose
-        lengths define the split points. Returns one (pred_reduced, gt_reduced)
-        tuple per rank, with gt_reduced None when GT embeddings are not collected.
+        Single-process (RANK == -1): passthrough. Under DDP, RANK 0 receives the
+        flattened lists from all ranks (and performs all downstream run updates);
+        other ranks get their inputs back unchanged but do not act on them.
+
+        Returns (table_url_strs, metrics_infos, pred_instance_counts, input_table_urls).
         """
-        per_rank_reduced = []
-        pred_offset = 0
-        gt_offset = 0
-        for rank_pred, rank_gt in gathered:
-            n_pred, n_gt = len(rank_pred), len(rank_gt)
-            per_rank_reduced.append(
-                (
-                    pred_reduced_all[pred_offset : pred_offset + n_pred],
-                    gt_reduced_all[gt_offset : gt_offset + n_gt] if gt_reduced_all is not None else None,
-                )
+        if RANK < 0:
+            return table_url_strs, metrics_infos, pred_instance_counts, [input_table_url]
+
+        world_size = dist.get_world_size()  # type: ignore[possibly-missing-attribute]
+        payload = (table_url_strs, metrics_infos, pred_instance_counts, input_table_url)
+        gathered = [None] * world_size if RANK == 0 else None
+        dist.gather_object(payload, gathered, dst=0)  # type: ignore[possibly-missing-attribute]
+
+        input_table_urls: list[str] = []
+        if RANK == 0:
+            assert gathered is not None
+            table_url_strs, metrics_infos, pred_instance_counts = [], [], []
+            for rank_table_urls, rank_metrics_infos, rank_counts, _ in gathered:
+                table_url_strs.extend(rank_table_urls)
+                metrics_infos.extend(rank_metrics_infos)
+                pred_instance_counts.extend(rank_counts)
+
+            # Collect unique input table URLs (should all be the same in distributed validation)
+            input_table_urls = list({rank_input_url for _, _, _, rank_input_url in gathered})
+
+        return table_url_strs, metrics_infos, pred_instance_counts, input_table_urls
+
+    def _reduce_and_rewrite_raw_tables(self, raw_table_urls, pred_instance_counts, row_counts):
+        """TEMP(embeddings): reduce raw embeddings from the flushed raw tables and
+        rewrite each into a table with reduced embedding columns.
+
+        Instance embeddings: the ``..._raw`` columns are replaced by reduced
+        ``predicted_instance_embedding`` / ``ground_truth_instance_embedding``
+        columns. Image embeddings: the raw ``embeddings`` column is replaced by
+        ``embeddings_{reducer}``, the same column name core 3LC's reduction
+        produces.
+
+        Each reducer is fitted on a uniform random sample of at most the
+        configured fit sample size drawn across the raw tables (or reused from
+        an earlier split of the same run via the per-run reducer registry), and
+        every row/instance is projected into the fitted space with the
+        reducer's transform. Tables are processed one at a time and evicted
+        from the object caches when done, so peak memory is bounded by a single
+        table regardless of dataset size.
+
+        Returns the metrics infos of the rewritten tables, or None when no
+        rewrite was performed (no tables, or the image-embeddings fit failed
+        while instance embeddings are disabled — the raw tables are then kept).
+        Goes away when core 3LC reduces these columns server-side; the raw
+        columns are already tagged ``NUMBER_ROLE_NN_EMBEDDING`` for that future
+        flow.
+        """
+        if not raw_table_urls:
+            return None
+
+        # Fit on this split's sampled embeddings, or reuse the run's cross-split
+        # reducers if an earlier split already fitted them.
+        instance_reducer = (
+            self._fit_or_reuse_instance_reducer(raw_table_urls, pred_instance_counts)
+            if self._settings.instance_embeddings_dim > 0
+            else None
+        )
+        image_reducer = (
+            self._fit_or_reuse_image_reducer(raw_table_urls, row_counts)
+            if self._settings.image_embeddings_dim > 0
+            else None
+        )
+
+        # Nothing to rewrite: instance embeddings are off and the image fit failed, so
+        # keep the raw tables (with the raw 'embeddings' column) as they were written.
+        if self._settings.instance_embeddings_dim == 0 and image_reducer is None:
+            return None
+
+        dst_writer = None
+        for url_str in raw_table_urls:
+            raw_table = tlc.Table.from_url(url_str)
+            if dst_writer is None:
+                dst_writer = self._reduced_table_writer(raw_table, image_reducer)
+            self._rewrite_raw_table(raw_table, instance_reducer, image_reducer, dst_writer)
+            # Evict the processed table so only one raw table is in RAM at a time.
+            ObjectRegistry._delete_object_from_caches(raw_table.url)
+            del raw_table
+
+        assert dst_writer is not None
+        _, reduced_metrics_infos = dst_writer.finalize()
+        return reduced_metrics_infos
+
+    def _fit_or_reuse_instance_reducer(self, raw_table_urls, pred_instance_counts):
+        """TEMP(instance-embeddings): return the run's instance reducer, fitting it
+        on sampled predicted embeddings when this is the first split to reduce.
+
+        Returns None when there are no predicted instances to fit on (a warning
+        is logged; the reduced columns are then written empty).
+        """
+        from tlc_ultralytics.utils._instance_reduce import (
+            _fit_embeddings_reducer,
+            _get_fitted_reducer,
+            _read_raw_embedding_column,
+            _set_fitted_reducer,
+        )
+
+        run_url_str = self._run.url.to_str()
+        reducer = _get_fitted_reducer(run_url_str, "instance")
+        if reducer is not None:
+            return reducer
+
+        sample = self._sample_embeddings_across_tables(
+            raw_table_urls,
+            pred_instance_counts,
+            self._settings.instance_embeddings_fit_sample_size,
+            lambda table: _read_raw_embedding_column(table, PREDICTED_INSTANCE_EMBEDDING_RAW)[0],
+        )
+        if sample is None:
+            msg = (
+                "No predicted instances were available to fit the instance-embeddings reducer "
+                f"for this split (conf_thres={self._settings.conf_thres}); instance embeddings "
+                "will be empty."
             )
-            pred_offset += n_pred
-            gt_offset += n_gt
-        return per_rank_reduced
+            if self._settings.ground_truth_instance_embeddings:
+                msg += " Ground-truth instance embeddings will be empty too."
+            LOGGER.warning(f"{TLC_COLORSTR}{msg}")
+            return None
 
-    def _fit_and_rewrite(self, raw_table):
-        """TEMP(instance-embeddings): fit the reducer on accumulated raw
-        embeddings, then rewrite the just-finalized metrics table into a new
-        one with reduced ``predicted_instance_embedding`` /
-        ``ground_truth_instance_embedding`` columns in place of the
-        ``..._raw`` columns.
+        reducer = _fit_embeddings_reducer(
+            sample,
+            method=self._settings.instance_embeddings_reducer,
+            n_components=self._settings.instance_embeddings_dim,
+            progress_callback=getattr(self._settings, "_reduction_progress_callback", None),
+            label="instance",
+            **(self._settings.instance_embeddings_reducer_kwargs or {}),
+        )
+        _set_fitted_reducer(run_url_str, "instance", reducer)
+        return reducer
 
-        Iterates *raw_table* sample-by-sample (RLE-encoded heavy fields decode
-        to numpy and re-encode through ``add_batch``; this is bounded memory
-        because only one image's worth of samples is materialized at a time
-        before being flushed in a small batch). Cross-split fit/transform is
-        preserved via the per-run reducer registry in ``_instance_reduce``.
+    def _fit_or_reuse_image_reducer(self, raw_table_urls, row_counts):
+        """TEMP(image-embeddings): return the run's image reducer, fitting it on
+        sampled image embeddings when this is the first split to reduce.
 
-        Goes away when core 3LC reduces variable-length embedding list
-        columns server-side. The raw column it leaves behind is already tagged
-        ``NUMBER_ROLE_NN_EMBEDDING`` for that future flow.
+        Returns None when the fit fails or there is nothing to fit on (a warning
+        is logged; the raw ``embeddings`` column is then kept as written).
         """
+        from tlc_ultralytics.utils._instance_reduce import (
+            _fit_embeddings_reducer,
+            _get_fitted_reducer,
+            _read_image_embedding_column,
+            _set_fitted_reducer,
+        )
+
+        run_url_str = self._run.url.to_str()
+        reducer = _get_fitted_reducer(run_url_str, "image")
+        if reducer is not None:
+            return reducer
+
+        sample = self._sample_embeddings_across_tables(
+            raw_table_urls,
+            row_counts,
+            self._settings.image_embeddings_fit_sample_size,
+            lambda table: _read_image_embedding_column(table, "embeddings"),
+        )
+        if sample is None:
+            return None
+
+        reducer_args = dict(self._settings.image_embeddings_reducer_args or {})
+        reducer_args.pop("n_components", None)  # provided via image_embeddings_dim
+        try:
+            reducer = _fit_embeddings_reducer(
+                sample,
+                method=self._settings.image_embeddings_reducer,
+                n_components=self._settings.image_embeddings_dim,
+                progress_callback=getattr(self._settings, "_reduction_progress_callback", None),
+                label="image",
+                **reducer_args,
+            )
+        except Exception as exc:
+            LOGGER.warning(
+                f"{TLC_COLORSTR}Fitting the image-embeddings reducer failed: {exc}. The raw "
+                "'embeddings' column is kept in the written metrics tables."
+            )
+            return None
+
+        _set_fitted_reducer(run_url_str, "image", reducer)
+        return reducer
+
+    def _sample_embeddings_across_tables(self, raw_table_urls, per_table_counts, sample_size, read_matrix):
+        """TEMP(embeddings): draw a uniform random sample of embedding vectors
+        across the flushed raw tables for fitting a reducer.
+
+        ``per_table_counts`` gives the number of candidate vectors per table
+        (predicted instances for instance embeddings, rows for image
+        embeddings), so the sample can be allocated across tables (multivariate
+        hypergeometric — exactly uniform over all vectors) with only one table
+        loaded at a time. ``read_matrix`` reads one table's candidate vectors
+        as a [N, C] matrix (or None).
+
+        Returns a [K, C] float32 matrix, or None when there are no candidates.
+        """
+        counts = np.asarray(per_table_counts, dtype=np.int64)
+        total = int(counts.sum())
+        if total == 0:
+            return None
+
+        rng = np.random.default_rng()
+        per_table_sample_sizes = rng.multivariate_hypergeometric(counts, min(sample_size, total))
+
+        parts = []
+        for url_str, table_sample_size in zip(raw_table_urls, per_table_sample_sizes, strict=True):
+            if table_sample_size == 0:
+                continue
+            table = tlc.Table.from_url(url_str)
+            matrix = read_matrix(table)
+            ObjectRegistry._delete_object_from_caches(table.url)
+            del table
+            if matrix is None:
+                continue
+            table_sample_size = min(int(table_sample_size), matrix.shape[0])
+            indices = np.sort(rng.choice(matrix.shape[0], size=table_sample_size, replace=False))
+            parts.append(matrix[indices].copy())  # copy so the full matrix can be freed
+
+        if not parts:
+            return None
+        return np.concatenate(parts, axis=0)
+
+    def _reduced_table_writer(self, raw_table, image_reducer):
+        """TEMP(embeddings): build the rolling writer for the reduced tables —
+        the raw table's schema with the raw embedding columns replaced by
+        reduced ones."""
         n = self._settings.instance_embeddings_dim
-        pred_reduced, gt_reduced = self._compute_reduced_instance_embeddings()
-
-        # Reduced embeddings are written back onto rows positionally, so guard the alignment:
-        # one per-image entry per row, else a reorder would silently misalign embeddings.
-        num_rows = len(raw_table)
-        assert len(pred_reduced) == num_rows, (
-            f"Instance embedding row count mismatch: {len(pred_reduced)} reduced entries for {num_rows} rows."
-        )
-        if gt_reduced is not None:
-            assert len(gt_reduced) == num_rows, (
-                f"Ground-truth instance embedding row count mismatch: {len(gt_reduced)} entries for {num_rows} rows."
+        schema_values = dict(raw_table.rows_schema.values)
+        has_pred = schema_values.pop(PREDICTED_INSTANCE_EMBEDDING_RAW, None) is not None
+        has_gt = schema_values.pop(GROUND_TRUTH_INSTANCE_EMBEDDING_RAW, None) is not None
+        if has_pred:
+            schema_values[PREDICTED_INSTANCE_EMBEDDING] = _instance_embeddings_list_schema(
+                n, display_name=f"Predicted Instance Embedding ({n}D)"
             )
-
-        # Drop raw buffers — fit is done and we re-read raw values from the
-        # source table during rewrite (where they're tiny pyarrow lists, not
-        # numpy arrays).
-        self._raw_pred_emb = []
-        self._raw_gt_emb = []
-
-        # Build destination schema: source columns minus the raw embedding
-        # columns, plus the reduced ones.
-        src_schema_values = dict(raw_table.rows_schema.values)
-        src_schema_values.pop(PREDICTED_INSTANCE_EMBEDDING_RAW, None)
-        src_schema_values.pop(GROUND_TRUTH_INSTANCE_EMBEDDING_RAW, None)
-        src_schema_values[PREDICTED_INSTANCE_EMBEDDING] = _instance_embeddings_list_schema(
-            n, display_name=f"Predicted Instance Embedding ({n}D)"
-        )
-        if gt_reduced is not None:
-            src_schema_values[GROUND_TRUTH_INSTANCE_EMBEDDING] = _instance_embeddings_list_schema(
+        if has_gt:
+            schema_values[GROUND_TRUTH_INSTANCE_EMBEDDING] = _instance_embeddings_list_schema(
                 n, display_name=f"Ground Truth Instance Embedding ({n}D)"
             )
 
-        dst_writer = tlc.MetricsTableWriter(
+        if image_reducer is not None and "embeddings" in schema_values:
+            schema_values.pop("embeddings")
+            method = self._settings.image_embeddings_reducer
+            schema_values[f"embeddings_{method}"] = _reduced_image_embeddings_schema(
+                self._settings.image_embeddings_dim, method
+            )
+
+        return _RollingMetricsWriter(
             run_url=self._run.url,
             foreign_table_url=self.dataloader.dataset.table.url,
-            schema=src_schema_values,
+            schema=schema_values,
+            max_buffer_bytes=self._settings.metrics_max_buffer_mb * 1024 * 1024,
         )
+
+    def _rewrite_raw_table(self, raw_table, instance_reducer, image_reducer, dst_writer):
+        """TEMP(embeddings): copy one raw table into *dst_writer* with the raw
+        embedding columns replaced by reduced ones.
+
+        Raw embeddings are read columnar (no per-row decode) and transformed in
+        chunks; the remaining columns are copied row by row (RLE-encoded heavy
+        fields decode to numpy and re-encode through ``add_batch``, one small
+        batch at a time). Memory is bounded by this one table plus the
+        destination writer's buffer.
+        """
+        reduced_columns, skip_columns = self._compute_reduced_columns(raw_table, instance_reducer, image_reducer)
 
         BATCH_SIZE = 32
 
         chunk: dict[str, list] = {}
         chunk_size = 0
-        pred_offset = 0
-        gt_offset = 0
+        offset = 0
 
         def flush() -> None:
-            nonlocal chunk, chunk_size, pred_offset, gt_offset
+            nonlocal chunk, chunk_size, offset
             if chunk_size == 0:
                 return
-            chunk[PREDICTED_INSTANCE_EMBEDDING] = [
-                arr.astype(np.float32).tolist() for arr in pred_reduced[pred_offset : pred_offset + chunk_size]
-            ]
-            pred_offset += chunk_size
-            if gt_reduced is not None:
-                chunk[GROUND_TRUTH_INSTANCE_EMBEDDING] = [
-                    arr.astype(np.float32).tolist() for arr in gt_reduced[gt_offset : gt_offset + chunk_size]
-                ]
-                gt_offset += chunk_size
+            for column_name, per_row_values in reduced_columns.items():
+                chunk[column_name] = per_row_values[offset : offset + chunk_size]
             dst_writer.add_batch(chunk)
+            offset += chunk_size
             chunk = {}
             chunk_size = 0
 
         for sample in raw_table:
             for col, val in sample.items():
-                if col in (PREDICTED_INSTANCE_EMBEDDING_RAW, GROUND_TRUTH_INSTANCE_EMBEDDING_RAW):
+                if col in skip_columns:
                     continue
                 chunk.setdefault(col, []).append(val)
             chunk_size += 1
@@ -942,8 +1024,82 @@ class TLCValidatorMixin(BaseValidator):
                 flush()
         flush()
 
-        dst_table = dst_writer.finalize()
-        return dst_table, dst_writer.get_written_metrics_infos()
+    def _compute_reduced_columns(self, raw_table, instance_reducer, image_reducer):
+        """TEMP(embeddings): compute one raw table's reduced embedding columns.
+
+        Returns (reduced_columns, skip_columns): the output column names mapped
+        to per-row lists of reduced values, and the raw source columns to drop
+        while copying the table's remaining columns.
+
+        Reduced embeddings are written back onto rows positionally, so row
+        counts are asserted — a reorder would silently misalign embeddings.
+        """
+        from tlc_ultralytics.utils._instance_reduce import _read_image_embedding_column, _transform_embeddings
+
+        progress_cb = getattr(self._settings, "_reduction_progress_callback", None)
+        num_rows = len(raw_table)
+        reduced_columns: dict[str, list] = {}
+        skip_columns: set[str] = set()
+
+        if PREDICTED_INSTANCE_EMBEDDING_RAW in raw_table.rows_schema.values:
+            pred_reduced = self._transform_raw_column(
+                raw_table, PREDICTED_INSTANCE_EMBEDDING_RAW, instance_reducer, progress_cb, label="predicted"
+            )
+            assert len(pred_reduced) == num_rows, (
+                f"Instance embedding row count mismatch: {len(pred_reduced)} reduced entries for {num_rows} rows."
+            )
+            reduced_columns[PREDICTED_INSTANCE_EMBEDDING] = [arr.astype(np.float32).tolist() for arr in pred_reduced]
+            skip_columns.add(PREDICTED_INSTANCE_EMBEDDING_RAW)
+
+        if GROUND_TRUTH_INSTANCE_EMBEDDING_RAW in raw_table.rows_schema.values:
+            gt_reduced = self._transform_raw_column(
+                raw_table, GROUND_TRUTH_INSTANCE_EMBEDDING_RAW, instance_reducer, progress_cb, label="ground-truth"
+            )
+            reduced_columns[GROUND_TRUTH_INSTANCE_EMBEDDING] = [arr.astype(np.float32).tolist() for arr in gt_reduced]
+            skip_columns.add(GROUND_TRUTH_INSTANCE_EMBEDDING_RAW)
+
+        if image_reducer is not None and "embeddings" in raw_table.rows_schema.values:
+            matrix = _read_image_embedding_column(raw_table, "embeddings")
+            if matrix is not None:
+                image_reduced = _transform_embeddings(
+                    [matrix],
+                    image_reducer,
+                    n_components=self._settings.image_embeddings_dim,
+                    progress_callback=progress_cb,
+                    label="image",
+                )[0]
+                assert len(image_reduced) == num_rows, (
+                    f"Image embedding row count mismatch: {len(image_reduced)} reduced entries for {num_rows} rows."
+                )
+                reduced_image_column = f"embeddings_{self._settings.image_embeddings_reducer}"
+                reduced_columns[reduced_image_column] = [row.tolist() for row in image_reduced]
+                skip_columns.add("embeddings")
+
+        return reduced_columns, skip_columns
+
+    def _transform_raw_column(self, raw_table, column_name, reducer, progress_callback, label):
+        """TEMP(instance-embeddings): read one raw instance embedding column and
+        project it into the reduced space, returning one [N_i, dim] array per
+        table row.
+
+        With no fitted reducer (no predicted instances anywhere in the split),
+        every row gets an empty array so the reduced column is still written.
+        """
+        from tlc_ultralytics.utils._instance_reduce import (
+            _read_raw_embedding_column,
+            _transform_embeddings,
+        )
+
+        n = self._settings.instance_embeddings_dim
+        matrix, per_row_counts = _read_raw_embedding_column(raw_table, column_name)
+
+        if matrix is None or reducer is None:
+            return [np.empty((0, n), dtype=np.float32) for _ in range(len(per_row_counts))]
+
+        reduced = _transform_embeddings(
+            [matrix], reducer, n_components=n, progress_callback=progress_callback, label=label
+        )[0]
+        return np.split(reduced, np.cumsum(per_row_counts)[:-1])
 
     def _remove_metrics_infos_from_run(self, metrics_infos) -> None:
         """Remove metrics infos that ``MetricsTableWriter.finalize()`` auto-registered.
@@ -957,21 +1113,21 @@ class TLCValidatorMixin(BaseValidator):
         if len(remaining) != len(self._run.metrics):
             self._run.update_attributes({"metrics": remaining})
 
-    def _delete_table_on_disk(self, table: tlc.Table) -> None:
+    def _delete_table_on_disk(self, table_url: tlc.Url) -> None:
         """Best-effort removal of an unregistered intermediate metrics table.
 
-        We keep the raw streaming table around just long enough to read it
-        back during ``_fit_and_rewrite``; after that it's an orphaned
-        directory under the run that nothing references.
+        We keep the raw streaming tables around just long enough to read them
+        back during ``_reduce_and_rewrite_raw_tables``; after that they're
+        orphaned directories under the run that nothing references.
         """
         try:
-            ObjectRegistry._delete_object_from_caches(table.url)
+            ObjectRegistry._delete_object_from_caches(table_url)
         except Exception:
             pass
         try:
-            table.url.delete()
+            table_url.delete()
         except Exception as exc:
-            LOGGER.warning(f"{TLC_COLORSTR}Failed to delete intermediate raw metrics table at {table.url}: {exc}")
+            LOGGER.warning(f"{TLC_COLORSTR}Failed to delete intermediate raw metrics table at {table_url}: {exc}")
 
     def _write_per_class_metrics_tables(self) -> None:
         if self.args.task not in ("detect", "segment", "obb"):

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -742,7 +742,11 @@ class TLCValidatorMixin(BaseValidator):
 
         world_size = dist.get_world_size()  # type: ignore[possibly-missing-attribute]
         payload = (table_url_strs, metrics_infos, pred_instance_counts, input_table_url)
-        gathered = [None] * world_size if RANK == 0 else None
+        # gather_object fills this in place on RANK 0 with each rank's payload tuple;
+        # annotate so the post-gather element type (not None) is known to the type checker.
+        gathered: list[tuple[list[str], list, list[int], str]] | None = (
+            [None] * world_size if RANK == 0 else None
+        )
         dist.gather_object(payload, gathered, dst=0)  # type: ignore[possibly-missing-attribute]
 
         input_table_urls: list[str] = []

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -861,13 +861,15 @@ class TLCValidatorMixin(BaseValidator):
             LOGGER.warning(f"{TLC_COLORSTR}{msg}")
             return None
 
+        reducer_kwargs = dict(self._settings.instance_embeddings_reducer_kwargs or {})
+        reducer_kwargs.pop("n_components", None)  # provided via instance_embeddings_dim
         reducer = _fit_embeddings_reducer(
             sample,
             method=self._settings.instance_embeddings_reducer,
             n_components=self._settings.instance_embeddings_dim,
             progress_callback=getattr(self._settings, "_reduction_progress_callback", None),
             label="instance",
-            **(self._settings.instance_embeddings_reducer_kwargs or {}),
+            **reducer_kwargs,
         )
         _set_fitted_reducer(run_url_str, "instance", reducer)
         return reducer

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -530,14 +530,15 @@ class TLCValidatorMixin(BaseValidator):
         In DDP mode, each rank collects metrics for its portion of the data.
         These are gathered to RANK 0 in _post_validation.
 
-        All metrics stream through a rolling writer that flushes to a new
-        metrics table whenever its in-memory buffer exceeds
-        ``Settings.metrics_max_buffer_mb``, so peak host memory is bounded
-        regardless of dataset size. When instance_embeddings_dim > 0, raw
-        per-instance embeddings are written inline as
-        ``predicted_instance_embedding_raw`` / ``ground_truth_..._raw`` columns
-        and reduced from the written tables at end of pass — nothing
-        accumulates in RAM here.
+        All metrics stream through a rolling writer that flushes to a new metrics table whenever its in-memory
+        buffer exceeds `Settings.metrics_max_buffer_mb`, so the buffer itself does not grow with dataset size.
+        When instance_embeddings_dim > 0, raw per-instance embeddings are written inline as
+        `predicted_instance_embedding_raw` / `ground_truth_..._raw` columns and reduced from the written tables
+        at end of pass, so they are not held in RAM here either.
+
+        This bounds the metrics buffer only. Two other terms still scale with the pass and are outside this
+        writer's reach: the dataloader worker processes, and Ultralytics' own `validator.metrics.stats`, which
+        retains six numpy arrays per image so it can compute mAP over the full split (~4.5 MB per 1000 images).
         """
         batch_size = self._infer_batch_size(preds, batch)
 

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -744,9 +744,7 @@ class TLCValidatorMixin(BaseValidator):
         payload = (table_url_strs, metrics_infos, pred_instance_counts, input_table_url)
         # gather_object fills this in place on RANK 0 with each rank's payload tuple;
         # annotate so the post-gather element type (not None) is known to the type checker.
-        gathered: list[tuple[list[str], list, list[int], str]] | None = (
-            [None] * world_size if RANK == 0 else None
-        )
+        gathered: list[tuple[list[str], list, list[int], str]] | None = [None] * world_size if RANK == 0 else None
         dist.gather_object(payload, gathered, dst=0)  # type: ignore[possibly-missing-attribute]
 
         input_table_urls: list[str] = []
@@ -809,8 +807,11 @@ class TLCValidatorMixin(BaseValidator):
         if self._settings.instance_embeddings_dim == 0 and image_reducer is None:
             return None
 
+        LOGGER.info(f"{TLC_COLORSTR}Reducing embeddings across {len(raw_table_urls)} metrics table(s)...")
+
         dst_writer = None
-        for url_str in raw_table_urls:
+        for table_number, url_str in enumerate(raw_table_urls, start=1):
+            LOGGER.debug(f"{TLC_COLORSTR}Reducing embeddings for metrics table {table_number}/{len(raw_table_urls)}.")
             raw_table = tlc.Table.from_url(url_str)
             if dst_writer is None:
                 dst_writer = self._reduced_table_writer(raw_table, image_reducer)
@@ -821,6 +822,7 @@ class TLCValidatorMixin(BaseValidator):
 
         assert dst_writer is not None
         _, reduced_metrics_infos = dst_writer.finalize()
+        LOGGER.info(f"{TLC_COLORSTR}Done reducing embeddings.")
         return reduced_metrics_infos
 
     def _fit_or_reuse_instance_reducer(self, raw_table_urls, pred_instance_counts):
@@ -1041,13 +1043,14 @@ class TLCValidatorMixin(BaseValidator):
         from tlc_ultralytics.utils._instance_reduce import _read_image_embedding_column, _transform_embeddings
 
         progress_cb = getattr(self._settings, "_reduction_progress_callback", None)
+        show_bar = self._should_show_reduction_bar()
         num_rows = len(raw_table)
         reduced_columns: dict[str, list] = {}
         skip_columns: set[str] = set()
 
         if PREDICTED_INSTANCE_EMBEDDING_RAW in raw_table.rows_schema.values:
             pred_reduced = self._transform_raw_column(
-                raw_table, PREDICTED_INSTANCE_EMBEDDING_RAW, instance_reducer, progress_cb, label="predicted"
+                raw_table, PREDICTED_INSTANCE_EMBEDDING_RAW, instance_reducer, progress_cb, show_bar, label="predicted"
             )
             assert len(pred_reduced) == num_rows, (
                 f"Instance embedding row count mismatch: {len(pred_reduced)} reduced entries for {num_rows} rows."
@@ -1057,7 +1060,12 @@ class TLCValidatorMixin(BaseValidator):
 
         if GROUND_TRUTH_INSTANCE_EMBEDDING_RAW in raw_table.rows_schema.values:
             gt_reduced = self._transform_raw_column(
-                raw_table, GROUND_TRUTH_INSTANCE_EMBEDDING_RAW, instance_reducer, progress_cb, label="ground-truth"
+                raw_table,
+                GROUND_TRUTH_INSTANCE_EMBEDDING_RAW,
+                instance_reducer,
+                progress_cb,
+                show_bar,
+                label="ground-truth",
             )
             reduced_columns[GROUND_TRUTH_INSTANCE_EMBEDDING] = [arr.astype(np.float32).tolist() for arr in gt_reduced]
             skip_columns.add(GROUND_TRUTH_INSTANCE_EMBEDDING_RAW)
@@ -1071,6 +1079,7 @@ class TLCValidatorMixin(BaseValidator):
                     n_components=self._settings.image_embeddings_dim,
                     progress_callback=progress_cb,
                     label="image",
+                    show_progress_bar=show_bar,
                 )[0]
                 assert len(image_reduced) == num_rows, (
                     f"Image embedding row count mismatch: {len(image_reduced)} reduced entries for {num_rows} rows."
@@ -1081,7 +1090,20 @@ class TLCValidatorMixin(BaseValidator):
 
         return reduced_columns, skip_columns
 
-    def _transform_raw_column(self, raw_table, column_name, reducer, progress_callback, label):
+    def _should_show_reduction_bar(self) -> bool:
+        """Whether to draw a default tqdm bar for the transform step.
+
+        Only when no reduction progress callback was supplied (the caller drives its own
+        reporting otherwise), on the main process, and to an interactive stdout — so DDP ranks
+        and non-interactive environments (logs, CI) stay quiet.
+        """
+        import sys
+
+        if getattr(self._settings, "_reduction_progress_callback", None) is not None:
+            return False
+        return RANK in {-1, 0} and sys.stdout.isatty()
+
+    def _transform_raw_column(self, raw_table, column_name, reducer, progress_callback, show_progress_bar, label):
         """TEMP(instance-embeddings): read one raw instance embedding column and
         project it into the reduced space, returning one [N_i, dim] array per
         table row.
@@ -1101,7 +1123,12 @@ class TLCValidatorMixin(BaseValidator):
             return [np.empty((0, n), dtype=np.float32) for _ in range(len(per_row_counts))]
 
         reduced = _transform_embeddings(
-            [matrix], reducer, n_components=n, progress_callback=progress_callback, label=label
+            [matrix],
+            reducer,
+            n_components=n,
+            progress_callback=progress_callback,
+            label=label,
+            show_progress_bar=show_progress_bar,
         )[0]
         return np.split(reduced, np.cumsum(per_row_counts)[:-1])
 

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -30,8 +30,8 @@ class Settings:
     max_det: int = field(default=300)
     """Maximum number of detections collected per image. Default: 300"""
 
-    metrics_max_buffer_mb: int = field(default=2048)
-    """Maximum size in MB of metrics in memory before they are flushed to a metrics table in storage. Default: 2048"""
+    metrics_max_buffer_mb: int = field(default=256)
+    """Maximum size in MB of metrics in memory before they are flushed to a metrics table in storage. Default: 256"""
 
     project_name: str | None = field(default=None)
     """The name of the 3LC project. Default: None"""

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -30,6 +30,9 @@ class Settings:
     max_det: int = field(default=300)
     """Maximum number of detections collected per image. Default: 300"""
 
+    metrics_max_buffer_mb: int = field(default=2048)
+    """Maximum size in MB of metrics in memory before they are flushed to a metrics table in storage. Default: 2048"""
+
     project_name: str | None = field(default=None)
     """The name of the 3LC project. Default: None"""
 
@@ -51,16 +54,18 @@ class Settings:
     """Image embeddings dimension. 0 means no embeddings, 2 means 2D embeddings, 3 means 3D embeddings. Default: 0"""
 
     image_embeddings_reducer: str = field(default="pacmap")
-    """Reduction algorithm for image embeddings. Options: pacmap and umap. Only used if IMAGE_EMBEDDINGS_DIM > 0.
-    Default: 'pacmap'"""
+    """Reduction algorithm for image embeddings. Options: 'pacmap', 'umap' and 'pca'.
+    Only used if IMAGE_EMBEDDINGS_DIM > 0. Default: 'pacmap'"""
 
     image_embeddings_reducer_args: dict = field(default_factory=dict)
-    """Reduction-method specific arguments to exert fine-grained control over the reduction process.
+    """Raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or
+    `sklearn.decomposition.PCA`) to exert fine-grained control over the reduction process. Default: {}"""
 
-    See [PaCMAPTableArgs](https://docs.3lc.ai/3lc/latest/apidocs/tlc/tlc.client.reduce.pacmap.html#tlc.client.reduce.pacmap.PaCMAPTableArgs)
-    or [UMAPTableArgs](https://docs.3lc.ai/3lc/latest/apidocs/tlc/tlc.client.reduce.umap.html#tlc.client.reduce.umap.UMAPTableArgs)
-     for more details.
-    """
+    image_embeddings_fit_sample_size: int = field(default=10_000)
+    """Maximum number of images the image-embeddings reducer is fitted on. When a split contains more images,
+    a uniform random sample of this size is used for the fit and all images are projected into the fitted
+    space with the reducer's transform. Bounds both the memory and the runtime of the fit on large datasets.
+    Default: 10000"""
 
     instance_embeddings_dim: int = field(default=0)
     """Per-instance embeddings dimension. 0 means disabled, 2 means 2D, 3 means 3D. Default: 0"""
@@ -78,6 +83,12 @@ class Settings:
     """Raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or
     `sklearn.decomposition.PCA`) — unlike `image_embeddings_reducer_args`, which takes 3LC
     reduction-table args. Default: {}"""
+
+    instance_embeddings_fit_sample_size: int = field(default=10_000)
+    """Maximum number of instances the instance-embeddings reducer is fitted on. When a split contains more
+    instances, a uniform random sample of this size is used for the fit and all instances are projected into the
+    fitted space with the reducer's transform. Bounds both the memory and the runtime of the fit on large
+    datasets. Default: 10000"""
 
     ground_truth_instance_embeddings: bool = field(default=False)
     """Whether to collect instance embeddings for ground-truth annotations.
@@ -243,8 +254,9 @@ class Settings:
             )
 
         if self.image_embeddings_dim > 0:
-            # The native 3LC reduction used for image embeddings supports pacmap and umap only.
-            self._check_reducer_available(self.image_embeddings_reducer, ("pacmap", "umap"), "image_embeddings_reducer")
+            self._check_reducer_available(
+                self.image_embeddings_reducer, ("pacmap", "umap", "pca"), "image_embeddings_reducer"
+            )
 
         assert self.instance_embeddings_dim >= 0, (
             f"Invalid instance embeddings dimension {self.instance_embeddings_dim}, must be non-negative."
@@ -264,12 +276,16 @@ class Settings:
             self._check_reducer_available(
                 self.instance_embeddings_reducer, ("pacmap", "umap", "pca"), "instance_embeddings_reducer"
             )
-            LOGGER.warning(
-                f"{TLC_COLORSTR}On large datasets or datasets with with many detections per image, instance embeddings "
-                "collection can use a lot of memory (tens of GB at full-COCO scale). To reduce it, collect on a "
-                "smaller split, lower max_det, or raise conf_thres. A memory-bounded path is planned, but not yet "
-                "available."
-            )
+
+        assert self.metrics_max_buffer_mb >= 0, (
+            f"Invalid metrics_max_buffer_mb {self.metrics_max_buffer_mb}, must be non-negative."
+        )
+        assert self.instance_embeddings_fit_sample_size > 0, (
+            f"Invalid instance_embeddings_fit_sample_size {self.instance_embeddings_fit_sample_size}, must be positive."
+        )
+        assert self.image_embeddings_fit_sample_size > 0, (
+            f"Invalid image_embeddings_fit_sample_size {self.image_embeddings_fit_sample_size}, must be positive."
+        )
 
         if self.ground_truth_instance_embeddings:
             assert self.instance_embeddings_dim > 0, (

--- a/src/tlc_ultralytics/settings.py
+++ b/src/tlc_ultralytics/settings.py
@@ -58,8 +58,9 @@ class Settings:
     Only used if IMAGE_EMBEDDINGS_DIM > 0. Default: 'pacmap'"""
 
     image_embeddings_reducer_args: dict = field(default_factory=dict)
-    """Raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or
-    `sklearn.decomposition.PCA`) to exert fine-grained control over the reduction process. Default: {}"""
+    """Raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or `sklearn.decomposition.PCA`)
+    to exert fine-grained control over the reduction process. `n_components` is set via `image_embeddings_dim` and
+    ignored here. Default: {}"""
 
     image_embeddings_fit_sample_size: int = field(default=10_000)
     """Maximum number of images the image-embeddings reducer is fitted on. When a split contains more images,
@@ -76,13 +77,12 @@ class Settings:
 
     instance_embeddings_reducer: str = field(default="pacmap")
     """Reduction algorithm for instance embeddings. Options: 'pacmap', 'umap' and 'pca'.
-    Only used if instance_embeddings_dim > 0. Experimental: reduced in-process for now,
-    and 'pca' is in-process only. Default: 'pacmap'"""
+    Only used if instance_embeddings_dim > 0. Experimental: reduced in-process for now. Default: 'pacmap'"""
 
     instance_embeddings_reducer_kwargs: dict = field(default_factory=dict)
-    """Raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or
-    `sklearn.decomposition.PCA`) — unlike `image_embeddings_reducer_args`, which takes 3LC
-    reduction-table args. Default: {}"""
+    """Raw constructor kwargs for the chosen reducer (`pacmap.PaCMAP`, `umap.UMAP` or `sklearn.decomposition.PCA`),
+    like `image_embeddings_reducer_args`. `n_components` is set via `instance_embeddings_dim` and ignored here.
+    Default: {}"""
 
     instance_embeddings_fit_sample_size: int = field(default=10_000)
     """Maximum number of instances the instance-embeddings reducer is fitted on. When a split contains more

--- a/src/tlc_ultralytics/utils/_instance_reduce.py
+++ b/src/tlc_ultralytics/utils/_instance_reduce.py
@@ -2,9 +2,9 @@
 
 3LC's native reducer (``Run.reduce_embeddings_by_foreign_table_url``) operates on
 fixed-size-list-per-row columns. Per-instance embeddings are variable-length
-(N detections per image, N varies per row), so this module flattens across the
-batch, fits/transforms with the configured reducer, and re-splits by per-image
-instance counts.
+(N detections per image, N varies per row), so this module fits the configured
+reducer on a bounded sample of raw instance embeddings read back from the written
+metrics tables, and transforms per-image embeddings into the fitted space.
 
 Delete this file and route reduction through the native 3LC API once upstream
 supports variable-length embedding list columns. All symbols here are private
@@ -13,131 +13,173 @@ supports variable-length embedding list columns. All symbols here are private
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
 from ultralytics.utils import LOGGER
 
 from tlc_ultralytics.constants import TLC_COLORSTR
 
-# Fitted reducers shared across one run's validation passes, keyed by run URL.
-# The first split to fit (train, by collect()'s split ordering) registers its
-# reducer here; later splits in the same run transform into that space. Cleared
-# by collect() once the run is done. Under DDP only RANK 0 fits, so only RANK 0
+if TYPE_CHECKING:
+    import tlc
+
+# Fitted reducers shared across one run's validation passes, keyed by
+# (run URL, kind) where kind is "instance" or "image". The first split to fit
+# (train, by collect()'s split ordering) registers its reducer here; later
+# splits in the same run transform into that space. Cleared by collect() and
+# the trainer once the run is done. Under DDP only RANK 0 fits, so only RANK 0
 # populates its registry. Dies with this module when native reduction lands.
-_fitted_reducers: dict[str, object] = {}
+_fitted_reducers: dict[tuple[str, str], object] = {}
 
 
-def _get_fitted_reducer(run_url: str) -> object | None:
-    """Return the reducer fitted earlier in this run, if any."""
-    return _fitted_reducers.get(run_url)
+def _get_fitted_reducer(run_url: str, kind: str) -> object | None:
+    """Return the reducer of the given kind fitted earlier in this run, if any."""
+    return _fitted_reducers.get((run_url, kind))
 
 
-def _set_fitted_reducer(run_url: str, reducer: object) -> None:
-    """Register a fitted reducer for reuse by later splits in the same run."""
-    _fitted_reducers[run_url] = reducer
+def _set_fitted_reducer(run_url: str, kind: str, reducer: object) -> None:
+    """Register a fitted reducer of the given kind for reuse by later splits in the same run."""
+    _fitted_reducers[(run_url, kind)] = reducer
 
 
-def _clear_fitted_reducer(run_url: str) -> None:
-    """Drop the run's fitted reducer (no-op if none was fitted)."""
-    _fitted_reducers.pop(run_url, None)
+def _clear_fitted_reducers(run_url: str) -> None:
+    """Drop all of the run's fitted reducers (no-op if none was fitted)."""
+    for key in [key for key in _fitted_reducers if key[0] == run_url]:
+        _fitted_reducers.pop(key, None)
 
 
-def _reduce_instance_embeddings(
-    raw_embeddings_per_image: list[np.ndarray],
+def _fit_embeddings_reducer(
+    sample: np.ndarray,
     method: str,
     n_components: int,
     progress_callback: object | None = None,
+    label: str = "instance",
     **reducer_args,
-) -> tuple[list[np.ndarray], object | None]:
-    """Flatten all instance embeddings, reduce, map back to per-image lists.
+) -> object:
+    """Fit the configured reducer on a matrix of sampled raw embeddings.
 
     Args:
-        raw_embeddings_per_image: list of [N_i, C] arrays
+        sample: [K, C] matrix of raw embeddings to fit on
         method: 'pacmap', 'umap', or 'pca'
         n_components: target dimensionality (2 or 3)
         progress_callback: Optional callable(phase, current, total) for progress reporting.
+        label: Human-readable label for log messages (e.g. "instance", "image").
 
     Returns:
-        Tuple of (reduced per-image lists, fitted reducer object).
-        The reducer can be passed to _transform_instance_embeddings for projecting
-        additional data (e.g. ground-truth embeddings) into the same space.
+        The fitted reducer object, ready for `_transform_embeddings`.
     """
-    counts = [emb.shape[0] for emb in raw_embeddings_per_image]
-    total_instances = sum(counts)
-
-    if total_instances == 0:
-        return [np.empty((0, n_components), dtype=np.float32) for _ in raw_embeddings_per_image], None
-
-    all_embeddings = np.concatenate([emb for emb in raw_embeddings_per_image if emb.shape[0] > 0], axis=0)
-
-    LOGGER.info(TLC_COLORSTR + f"Reducing {total_instances} instance embeddings to {n_components}D with {method}...")
+    LOGGER.info(
+        TLC_COLORSTR + f"Fitting {method} {label}-embeddings reducer ({n_components}D) on {len(sample)} samples..."
+    )
 
     if progress_callback:
-        progress_callback("fit", 0, total_instances)
+        progress_callback("fit", 0, len(sample))
 
     if method == "pacmap":
         import pacmap
 
         # PaCMAP needs save_tree=True for the fitted reducer to support .transform()
-        # on new data. We rely on that for GT embeddings and cross-split projection,
-        # so default it on (but let callers override via reducer_args).
+        # on new data. All reduced values are produced via .transform() (the fit runs
+        # on a sample), so default it on (but let callers override via reducer_args).
         reducer_args.setdefault("save_tree", True)
         reducer = pacmap.PaCMAP(n_components=n_components, **reducer_args)
-        reduced = reducer.fit_transform(all_embeddings)
+        reducer.fit(sample)
     elif method == "umap":
         import umap  # ty: ignore[unresolved-import]
 
         reducer = umap.UMAP(n_components=n_components, **reducer_args)
-        reduced = reducer.fit_transform(all_embeddings)
+        reducer.fit(sample)
     elif method == "pca":
         from sklearn.decomposition import PCA
 
         reducer = PCA(n_components=n_components, **reducer_args)
-        reduced = reducer.fit_transform(all_embeddings)
+        reducer.fit(sample)
     else:
         raise ValueError(f"Unknown reduction method: {method}")
 
-    reduced = reduced.astype(np.float32)
-
     if progress_callback:
-        progress_callback("fit", total_instances, total_instances)
+        progress_callback("fit", len(sample), len(sample))
 
-    result = []
-    idx = 0
-    for count in counts:
-        if count > 0:
-            result.append(reduced[idx : idx + count])
-            idx += count
-        else:
-            result.append(np.empty((0, n_components), dtype=np.float32))
+    return reducer
 
-    return result, reducer
+
+def _read_raw_embedding_column(table: tlc.Table, column_name: str) -> tuple[np.ndarray | None, np.ndarray]:
+    """Read a variable-length raw-embedding list column as a flat matrix plus per-row instance counts.
+
+    Reads the column directly as pyarrow data, avoiding per-row sample-type decoding and Python-object
+    materialization of the (potentially large) float lists.
+
+    Args:
+        table: the metrics table to read from (fully loaded into memory by the read; callers should evict it
+            from the object caches when done to bound memory across many tables)
+        column_name: name of the raw embedding column, a list of fixed-size float vectors per row
+
+    Returns:
+        Tuple of (matrix, per_row_counts) where matrix is a [total_instances, C] float32 array, or None when the
+        column holds no instances, and per_row_counts has one instance count per table row.
+    """
+    column = table.get_column_as_pyarrow_array(column_name)
+    per_row_counts = pc.list_value_length(column).to_numpy(zero_copy_only=False).astype(np.int64)
+
+    total_instances = int(per_row_counts.sum())
+    if total_instances == 0:
+        return None, per_row_counts
+
+    per_instance = column.flatten()  # one entry per instance, honoring row offsets
+    if isinstance(per_instance, pa.ChunkedArray):
+        per_instance = per_instance.combine_chunks()
+    flat_values = per_instance.flatten().to_numpy(zero_copy_only=False)
+
+    channels = flat_values.size // total_instances
+    matrix = flat_values.astype(np.float32, copy=False).reshape(total_instances, channels)
+    return matrix, per_row_counts
+
+
+def _read_image_embedding_column(table: tlc.Table, column_name: str) -> np.ndarray | None:
+    """Read a fixed-size per-row embedding column as a [n_rows, C] float32 matrix.
+
+    The image-embedding counterpart to `_read_raw_embedding_column`: one fixed-size vector per row instead
+    of a variable-length list of vectors. Returns None when the table has no rows.
+    """
+    column = table.get_column_as_pyarrow_array(column_name)
+    n_rows = len(column)
+    if n_rows == 0:
+        return None
+
+    flat = column.flatten()
+    if isinstance(flat, pa.ChunkedArray):
+        flat = flat.combine_chunks()
+    flat_values = flat.to_numpy(zero_copy_only=False).astype(np.float32, copy=False)
+    return flat_values.reshape(n_rows, flat_values.size // n_rows)
 
 
 _TRANSFORM_BATCH_SIZE = 5000
 
 
-def _transform_instance_embeddings(
+def _transform_embeddings(
     raw_embeddings_per_image: list[np.ndarray],
     reducer: object,
     n_components: int,
     progress_callback: object | None = None,
     label: str = "instance",
 ) -> list[np.ndarray]:
-    """Transform instance embeddings using an already-fitted reducer.
+    """Transform raw embeddings using an already-fitted reducer.
 
-    Projects new data (e.g. ground-truth embeddings) into the same embedding
-    space as the data the reducer was fitted on. Processes in batches of 5000
-    for progress reporting.
+    Projects new data (e.g. ground-truth or image embeddings) into the same
+    embedding space as the data the reducer was fitted on. Processes in batches
+    of 5000 for progress reporting.
 
     Args:
         raw_embeddings_per_image: list of [N_i, C] arrays
         reducer: A fitted PaCMAP, UMAP, or PCA reducer object
         n_components: target dimensionality (must match the reducer)
         progress_callback: Optional callable(phase, current, total) for progress reporting.
-        label: Human-readable label for log messages (e.g. "predicted", "ground-truth").
+        label: Human-readable label for log messages (e.g. "predicted", "ground-truth", "image").
 
     Returns:
-        list of [N_i, n_components] arrays (or empty arrays for images with no instances)
+        list of [N_i, n_components] arrays (or empty arrays for entries with no rows)
     """
     counts = [emb.shape[0] for emb in raw_embeddings_per_image]
     total_instances = sum(counts)
@@ -147,7 +189,7 @@ def _transform_instance_embeddings(
 
     all_embeddings = np.concatenate([emb for emb in raw_embeddings_per_image if emb.shape[0] > 0], axis=0)
 
-    LOGGER.info(TLC_COLORSTR + f"Transforming {total_instances} {label} instance embeddings to {n_components}D...")
+    LOGGER.info(TLC_COLORSTR + f"Transforming {total_instances} {label} embeddings to {n_components}D...")
 
     if progress_callback:
         progress_callback("transform", 0, total_instances)

--- a/src/tlc_ultralytics/utils/_instance_reduce.py
+++ b/src/tlc_ultralytics/utils/_instance_reduce.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
-from ultralytics.utils import LOGGER
+from ultralytics.utils import LOGGER, TQDM
 
 from tlc_ultralytics.constants import TLC_COLORSTR
 
@@ -164,6 +164,7 @@ def _transform_embeddings(
     n_components: int,
     progress_callback: object | None = None,
     label: str = "instance",
+    show_progress_bar: bool = False,
 ) -> list[np.ndarray]:
     """Transform raw embeddings using an already-fitted reducer.
 
@@ -177,6 +178,9 @@ def _transform_embeddings(
         n_components: target dimensionality (must match the reducer)
         progress_callback: Optional callable(phase, current, total) for progress reporting.
         label: Human-readable label for log messages (e.g. "predicted", "ground-truth", "image").
+        show_progress_bar: Draw a tqdm bar over the batches. Ignored when progress_callback is
+            given (the caller drives its own reporting); the caller is responsible for the TTY/RANK
+            guard so this stays quiet under DDP and in non-interactive environments.
 
     Returns:
         list of [N_i, n_components] arrays (or empty arrays for entries with no rows)
@@ -194,19 +198,24 @@ def _transform_embeddings(
     if progress_callback:
         progress_callback("transform", 0, total_instances)
 
-    if total_instances > _TRANSFORM_BATCH_SIZE:
-        reduced_parts = []
-        for start in range(0, total_instances, _TRANSFORM_BATCH_SIZE):
-            end = min(start + _TRANSFORM_BATCH_SIZE, total_instances)
-            chunk = all_embeddings[start:end]
-            reduced_parts.append(reducer.transform(chunk).astype(np.float32))
-            if progress_callback:
-                progress_callback("transform", end, total_instances)
-        reduced = np.concatenate(reduced_parts, axis=0)
-    else:
-        reduced = reducer.transform(all_embeddings).astype(np.float32)
+    pbar = None
+    if show_progress_bar and not progress_callback:
+        pbar = TQDM(total=total_instances, desc=f"{TLC_COLORSTR}Transforming {label} embeddings", unit=" emb")
+
+    # One batched loop covers both sizes: for total <= _TRANSFORM_BATCH_SIZE it runs a single
+    # iteration over the whole array, matching the un-chunked transform.
+    reduced_parts = []
+    for start in range(0, total_instances, _TRANSFORM_BATCH_SIZE):
+        end = min(start + _TRANSFORM_BATCH_SIZE, total_instances)
+        reduced_parts.append(reducer.transform(all_embeddings[start:end]).astype(np.float32))
         if progress_callback:
-            progress_callback("transform", total_instances, total_instances)
+            progress_callback("transform", end, total_instances)
+        if pbar is not None:
+            pbar.update(end - start)
+    reduced = np.concatenate(reduced_parts, axis=0)
+
+    if pbar is not None:
+        pbar.close()
 
     result = []
     idx = 0

--- a/src/tlc_ultralytics/utils/_rolling_writer.py
+++ b/src/tlc_ultralytics/utils/_rolling_writer.py
@@ -1,0 +1,115 @@
+"""Byte-bounded rolling wrapper around `tlc.MetricsTableWriter`.
+
+`tlc.MetricsTableWriter` buffers every added batch in RAM and only writes them out at `finalize()`, so a single
+writer's peak host memory grows with the total size of the pass — unbounded for large datasets with heavy per-row
+metrics such as RLE segmentation masks or raw instance embeddings. `_RollingMetricsWriter` bounds that growth by
+tracking the byte size of the buffered record batches and finalizing + replacing the inner writer whenever the buffer
+crosses a threshold. The resulting tables share a column signature and stream name, so the 3LC Dashboard joins them
+back together, and the `example_id` column identifies the rows.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+import tlc
+from tlc._core.object_registry import ObjectRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
+
+
+class _RollingMetricsWriter:
+    """Write metrics batches to a run, rolling to a new metrics table when buffered bytes cross a threshold."""
+
+    def __init__(
+        self,
+        *,
+        run_url: tlc.Url,
+        foreign_table_url: tlc.Url,
+        schema: dict[str, tlc.Schema],
+        max_buffer_bytes: int,
+        stream_name: str = "default_stream",
+    ) -> None:
+        """Initialize a rolling metrics writer.
+
+        :param run_url: The url of the run to write metrics tables for.
+        :param foreign_table_url: The url of the table the metrics rows refer to.
+        :param schema: Column schemas, deep-copied for each inner writer so writers never share schema objects.
+        :param max_buffer_bytes: Flush the buffered rows to a table and start a new one when the buffered pyarrow
+            record batches exceed this many bytes. 0 flushes after every batch.
+        :param stream_name: The metrics stream name shared by all written tables.
+        """
+        self._run_url = run_url
+        self._foreign_table_url = foreign_table_url
+        self._schema = schema
+        self._max_buffer_bytes = max_buffer_bytes
+        self._stream_name = stream_name
+
+        self._writer: tlc.MetricsTableWriter | None = None
+        self._buffered_bytes = 0
+        self._flushed_urls: list[tlc.Url] = []
+        self._flushed_infos: list[Mapping[str, Any]] = []
+        self._finalized = False
+
+    @property
+    def num_flushed_tables(self) -> int:
+        """The number of tables flushed so far; also the index of the table the next batch is written to."""
+        return len(self._flushed_urls)
+
+    def add_batch(self, batch: MutableMapping[str, Any]) -> None:
+        """Add a batch of metrics rows, rolling to a new table if the buffer threshold is crossed."""
+        if self._finalized:
+            raise RuntimeError("Cannot add batches to a finalized _RollingMetricsWriter.")
+
+        if self._writer is None:
+            self._writer = self._new_writer()
+
+        buffer_length_before = len(self._writer.buffer)
+        self._writer.add_batch(batch)
+        self._buffered_bytes += sum(rb.nbytes for rb in self._writer.buffer[buffer_length_before:])
+
+        if self._buffered_bytes >= self._max_buffer_bytes:
+            self._roll()
+
+    def finalize(self) -> tuple[list[tlc.Url], list[Mapping[str, Any]]]:
+        """Flush any remaining buffered rows and return (table urls, metrics infos) for all written tables.
+
+        The metrics infos have urls relative to the run url, as returned by
+        `MetricsTableWriter.get_written_metrics_infos`.
+        """
+        if self._finalized:
+            raise RuntimeError("finalize() has already been called on this _RollingMetricsWriter.")
+        self._finalized = True
+
+        if self._writer is not None:
+            if self._writer.row_count > 0:
+                self._roll()
+            else:
+                self._writer.clear()
+                self._writer = None
+
+        return self._flushed_urls, self._flushed_infos
+
+    def _new_writer(self) -> tlc.MetricsTableWriter:
+        # Deep-copy the column schemas so schema mutations made by one writer's pipeline (defaults merging,
+        # schema resolution) cannot leak into the next writer's.
+        return tlc.MetricsTableWriter(
+            run_url=self._run_url,
+            foreign_table_url=self._foreign_table_url,
+            schema=copy.deepcopy(self._schema),
+            stream_name=self._stream_name,
+        )
+
+    def _roll(self) -> None:
+        """Finalize the current inner writer and arrange for a fresh one on the next batch."""
+        assert self._writer is not None
+        table = self._writer.finalize()
+        self._flushed_infos.extend(self._writer.get_written_metrics_infos())
+        self._flushed_urls.append(table.url)
+
+        # Drop the table object and evict it from the object caches so flushed data doesn't linger in RAM.
+        ObjectRegistry._delete_object_from_caches(table.url)
+        self._writer = None
+        self._buffered_bytes = 0

--- a/src/tlc_ultralytics/utils/_rolling_writer.py
+++ b/src/tlc_ultralytics/utils/_rolling_writer.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING, Any
 
 import tlc
 from tlc._core.object_registry import ObjectRegistry
+from ultralytics.utils import LOGGER
+
+from tlc_ultralytics.constants import TLC_COLORSTR
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
@@ -105,9 +108,15 @@ class _RollingMetricsWriter:
     def _roll(self) -> None:
         """Finalize the current inner writer and arrange for a fresh one on the next batch."""
         assert self._writer is not None
+        row_count = self._writer.row_count
         table = self._writer.finalize()
         self._flushed_infos.extend(self._writer.get_written_metrics_infos())
         self._flushed_urls.append(table.url)
+
+        LOGGER.debug(
+            f"{TLC_COLORSTR}Flushed metrics table {len(self._flushed_urls)} "
+            f"({row_count} rows, {self._buffered_bytes / (1024 * 1024):.1f} MB) to {table.url}."
+        )
 
         # Drop the table object and evict it from the object caches so flushed data doesn't linger in RAM.
         ObjectRegistry._delete_object_from_caches(table.url)

--- a/src/tlc_ultralytics/utils/schemas.py
+++ b/src/tlc_ultralytics/utils/schemas.py
@@ -62,6 +62,33 @@ def _raw_instance_embeddings_schema(c_raw: int, display_name: str | None = None)
     )
 
 
+def _reduced_image_embeddings_schema(n_components: int, method: str) -> tlc.Schema:
+    """TEMP(image-embeddings): schema for the reduced per-image embedding column.
+
+    Mirrors the schema produced by core 3LC's dimensional-reduction tables: a fixed-size float32 vector whose
+    size dimension carries the `xy_component` / `xyz_component` number role, which is what makes the Dashboard
+    render the column as 2D/3D points. Goes away when reduction moves back to a core 3LC interface.
+
+    :param n_components: The number of reduced dimensions (2 or 3).
+    :param method: The reduction method name, used in the column name and descriptions.
+    :returns: A Schema for the reduced image embedding column.
+    """
+    from tlc.constants import NUMBER_ROLE_XY_COMPONENT, NUMBER_ROLE_XYZ_COMPONENT
+
+    number_role_mapping = {2: NUMBER_ROLE_XY_COMPONENT, 3: NUMBER_ROLE_XYZ_COMPONENT}
+
+    schema = Float32Schema(
+        display_name=f"embeddings_{method}",
+        description="A property containing the low-dimensional values of column 'embeddings'",
+        shape=(n_components,),
+        writable=False,
+    )
+    schema.size0.display_name = f"{method} component"
+    schema.size0.description = f"The size-n dimension of the {method} embedding"
+    schema.size0.number_role = number_role_mapping.get(n_components, f"{method} Component")
+    return schema
+
+
 def image_embeddings_schema(activation_size=512) -> tlc.Schema:
     """Create a 3LC schema for YOLO image embeddings.
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -26,7 +26,6 @@ from testing_helpers import (
     stub_model_with_stride,
 )
 from tlc._core.objects.tables.from_table.edited_table import EditedTable
-from tlc._core.objects.tables.from_table.pacmap_table import PacmapTable
 from tlc._core.objects.tables.null_overlay import NullOverlay
 from tlc.constants._run_status import RUN_STATUS_COMPLETED
 from tlc.helpers import KeypointHelper
@@ -635,12 +634,12 @@ def test_embeddings_collection() -> None:
 
     run = _get_run_from_settings(settings)
     assert len(run.metrics_tables) == 2, "Expected 2 metrics tables to be written"
-    assert any(isinstance(metrics_table, PacmapTable) for metrics_table in run.metrics_tables), "Expected a PaCMAPTable"
 
     embeddings_table = next(
-        metrics_table for metrics_table in run.metrics_tables if isinstance(metrics_table, PacmapTable)
+        (metrics_table for metrics_table in run.metrics_tables if "embeddings_pacmap" in metrics_table.columns),
+        None,
     )
-    assert "embeddings_pacmap" in embeddings_table.columns, "Expected embeddings column"
+    assert embeddings_table is not None, "Expected a metrics table with the reduced embeddings column"
 
     embeddings_column_arrow = embeddings_table.get_column_as_pyarrow_array("embeddings_pacmap")
     embeddings_column_list = embeddings_column_arrow.tolist()
@@ -3107,47 +3106,46 @@ def test_all_embeddings_combined() -> None:
 def test_instance_reducer_fit_then_transform(reducer: str) -> None:
     """Unit test: each reducer must survive a fit followed by a fresh .transform().
 
-    Exercises ``_reduce_instance_embeddings`` and ``_transform_instance_embeddings``
+    Exercises ``_fit_embeddings_reducer`` and ``_transform_embeddings``
     directly on synthetic data so the test doesn't depend on a full model run or
     the size of the YOLO test dataset. This is the scenario that catches pacmap's
     ``save_tree=True`` requirement — without it the fitted reducer can't project
-    GT embeddings into the predicted space.
+    instances outside the fit sample into the fitted space.
     """
     pytest.importorskip(reducer if reducer != "pca" else "sklearn")
 
     from tlc_ultralytics.utils._instance_reduce import (
-        _reduce_instance_embeddings,
-        _transform_instance_embeddings,
+        _fit_embeddings_reducer,
+        _transform_embeddings,
     )
 
     rng = np.random.default_rng(0)
-    raw_per_image = [rng.normal(size=(20, 32)).astype(np.float32) for _ in range(10)]
+    sample = rng.normal(size=(200, 32)).astype(np.float32)
 
     try:
         # random_state is a raw constructor kwarg for all three reducers; passing it through
         # exercises that instance_embeddings_reducer_kwargs are forwarded to the constructor.
-        reduced, fitted = _reduce_instance_embeddings(
-            raw_per_image,
+        fitted = _fit_embeddings_reducer(
+            sample,
             method=reducer,
             n_components=2,
             random_state=42,
         )
     except ValueError as exc:
-        # pacmap on macOS ARM currently fails during fit_transform with a
+        # pacmap on macOS ARM currently fails during fit with a
         # broadcast/shape error from its internal KNN. Skip rather than fail —
         # the post-fit .transform() path (the save_tree=True regression guard)
         # can only be checked when fit itself works.
         pytest.skip(f"{reducer} fit failed in this environment: {exc}")
 
     assert fitted is not None
-    assert all(r.shape == (20, 2) for r in reduced)
     # The forwarded kwarg reached the underlying reducer constructor.
     assert fitted.random_state == 42
 
     # Transform a disjoint batch with the fitted reducer — this crashes on
     # pacmap when save_tree=False, which is the bug the in-process reducer guards.
     new_raw = [rng.normal(size=(5, 32)).astype(np.float32) for _ in range(3)]
-    projected = _transform_instance_embeddings(new_raw, fitted, n_components=2)
+    projected = _transform_embeddings(new_raw, fitted, n_components=2)
     assert all(r.shape == (5, 2) for r in projected)
 
 
@@ -3175,10 +3173,9 @@ def test_gt_instance_embeddings_incompatible_with_collection_disable() -> None:
 
 
 def test_reducer_validation_split() -> None:
-    """pca is only supported by the in-process instance reduction, not the native image reduction."""
+    """pca is supported by the in-process reduction for both image and instance embeddings."""
     settings = Settings(image_embeddings_dim=2, image_embeddings_reducer="pca", label_column_name="test")
-    with pytest.raises(ValueError, match="image_embeddings_reducer"):
-        settings.verify(training=False)
+    settings.verify(training=False)
 
     settings = Settings(instance_embeddings_dim=2, instance_embeddings_reducer="pca", label_column_name="test")
     settings.verify(training=False)
@@ -3187,38 +3184,173 @@ def test_reducer_validation_split() -> None:
     with pytest.raises(ValueError, match="instance_embeddings_reducer"):
         settings.verify(training=False)
 
+    settings = Settings(image_embeddings_dim=2, image_embeddings_reducer="illegal", label_column_name="test")
+    with pytest.raises(ValueError, match="image_embeddings_reducer"):
+        settings.verify(training=False)
 
-def test_split_reduced_by_rank() -> None:
-    """Unit test for the DDP re-split of flattened reduced embeddings back to per-rank lists."""
-    from tlc_ultralytics.engine.validator import TLCValidatorMixin
 
-    rng = np.random.default_rng(0)
+def test_rolling_metrics_writer_rolls_by_bytes() -> None:
+    """Unit test: the rolling writer flushes to a new metrics table when the buffer threshold is crossed,
+    and the flushed tables together hold all rows in order."""
+    from tlc_ultralytics.utils._rolling_writer import _RollingMetricsWriter
 
-    def make_payload(n_images, n_instances):
-        return [rng.normal(size=(n_instances, 16)).astype(np.float32) for _ in range(n_images)]
+    run = tlc.init(project_name="test_rolling_writer", run_name="test_rolling_writer")
 
-    # Rank 0: 3 images, rank 1: 2 images (pred); GT counts differ from pred counts
-    gathered = [
-        (make_payload(3, 4), make_payload(3, 2)),
-        (make_payload(2, 4), make_payload(2, 2)),
-    ]
-    pred_reduced_all = [rng.normal(size=(4, 2)).astype(np.float32) for _ in range(5)]
-    gt_reduced_all = [rng.normal(size=(2, 2)).astype(np.float32) for _ in range(5)]
+    writer = _RollingMetricsWriter(
+        run_url=run.url,
+        foreign_table_url=run.url / "dummy_table",
+        schema={"value": tlc.schemas.Float32Schema()},
+        max_buffer_bytes=1,  # every batch crosses the threshold -> one table per batch
+    )
 
-    per_rank = TLCValidatorMixin._split_reduced_by_rank(gathered, pred_reduced_all, gt_reduced_all)
+    assert writer.num_flushed_tables == 0
+    for i in range(3):
+        writer.add_batch({"example_id": [2 * i, 2 * i + 1], "value": [0.5, 1.5]})
+        assert writer.num_flushed_tables == i + 1
 
-    assert len(per_rank) == 2
-    pred_r0, gt_r0 = per_rank[0]
-    pred_r1, gt_r1 = per_rank[1]
-    assert len(pred_r0) == 3 and len(gt_r0) == 3
-    assert len(pred_r1) == 2 and len(gt_r1) == 2
-    # Order is preserved: rank 1's first image is the 4th flattened entry
-    np.testing.assert_array_equal(pred_r1[0], pred_reduced_all[3])
-    np.testing.assert_array_equal(gt_r1[1], gt_reduced_all[4])
+    table_urls, metrics_infos = writer.finalize()
+    assert len(table_urls) == 3
+    assert len(metrics_infos) == 3
+    assert all(info["stream_name"] == "default_stream" for info in metrics_infos)
 
-    # Without GT, gt side is None for every rank
-    per_rank_no_gt = TLCValidatorMixin._split_reduced_by_rank(gathered, pred_reduced_all, None)
-    assert all(gt is None for _, gt in per_rank_no_gt)
+    df = pd.concat([tlc.Table.from_url(url).to_pandas() for url in table_urls], ignore_index=True)
+    assert sorted(df["example_id"].tolist()) == list(range(6))
+
+    # Each flushed table was registered on the run as it was written
+    run = tlc.Run.from_url(run.url)
+    registered_urls = {info["url"] for info in run.metrics}
+    assert {info["url"] for info in metrics_infos} <= registered_urls
+
+    # A finalized writer must reject further batches and repeated finalize calls
+    with pytest.raises(RuntimeError):
+        writer.add_batch({"example_id": [0], "value": [0.0]})
+    with pytest.raises(RuntimeError):
+        writer.finalize()
+
+
+def test_metrics_flushing_end_to_end() -> None:
+    """Collect with a zero buffer threshold: metrics are flushed to multiple tables that together
+    hold one row per dataset image."""
+    settings = Settings(
+        project_name="test_metrics_flushing",
+        run_name="test_metrics_flushing",
+        metrics_max_buffer_mb=0,  # flush after every batch
+    )
+
+    model = TLCYOLO(TASK2MODEL["detect"])
+    model.collect(data=TASK2DATASET["detect"], splits=("train",), settings=settings, batch=2, device="cpu", workers=0)
+
+    run = _get_run_from_settings(settings)
+    default_tables = get_metrics_tables_from_run(run)["default_stream"]
+    assert len(default_tables) >= 2, "Expected the zero buffer threshold to flush multiple metrics tables"
+
+    df = pd.concat([t.to_pandas() for t in default_tables], ignore_index=True)
+    assert sorted(df["example_id"].tolist()) == [0, 1, 2, 3], "Flushed tables should cover every image exactly once"
+
+
+def test_metrics_flushing_with_instance_embeddings() -> None:
+    """Collect with a zero buffer threshold and instance embeddings: every raw table is rewritten with a
+    reduced embedding column, raw columns and tables are gone, and rows are preserved."""
+    dim = 2
+    settings = Settings(
+        project_name="test_metrics_flushing_instance_emb",
+        run_name="test_metrics_flushing_instance_emb",
+        metrics_max_buffer_mb=0,  # flush after every batch
+        instance_embeddings_dim=dim,
+        instance_embeddings_reducer="pca",
+        instance_embeddings_fit_sample_size=5,  # force the sampled-fit path
+        label_column_name=TASK2LABEL_COLUMN_NAME["detect"],
+    )
+
+    model = TLCYOLO(TASK2MODEL["detect"])
+    model.collect(data=TASK2DATASET["detect"], splits=("train",), settings=settings, batch=2, device="cpu", workers=0)
+
+    run = _get_run_from_settings(settings)
+    default_tables = get_metrics_tables_from_run(run)["default_stream"]
+    assert len(default_tables) >= 2, "Expected the zero buffer threshold to flush multiple metrics tables"
+
+    df = pd.concat([t.to_pandas() for t in default_tables], ignore_index=True)
+    assert sorted(df["example_id"].tolist()) == [0, 1, 2, 3], "Rewritten tables should cover every image exactly once"
+
+    assert "predicted_instance_embedding" in df.columns, "Expected the reduced embedding column in every table"
+    assert "predicted_instance_embedding_raw" not in df.columns, "Raw embedding columns should have been rewritten"
+
+    total_instances = 0
+    for row_embs in df["predicted_instance_embedding"]:
+        for emb in row_embs:
+            assert len(emb) == dim
+            total_instances += 1
+    assert total_instances > 0, "Expected at least some reduced instance embeddings"
+
+
+def test_metrics_flushing_with_image_embeddings() -> None:
+    """Collect with a zero buffer threshold and image embeddings: the reducer is fitted on a sample drawn
+    across the flushed tables and every table is rewritten with the reduced column in place of the raw one."""
+    dim = 2
+    settings = Settings(
+        project_name="test_metrics_flushing_image_emb",
+        run_name="test_metrics_flushing_image_emb",
+        metrics_max_buffer_mb=0,  # flush after every batch
+        image_embeddings_dim=dim,
+        image_embeddings_reducer="pca",
+        image_embeddings_fit_sample_size=3,  # force the sampled-fit path (fewer than the 4 images)
+    )
+
+    model = TLCYOLO(TASK2MODEL["detect"])
+    model.collect(data=TASK2DATASET["detect"], splits=("train",), settings=settings, batch=2, device="cpu", workers=0)
+
+    run = _get_run_from_settings(settings)
+    default_tables = get_metrics_tables_from_run(run)["default_stream"]
+    assert len(default_tables) >= 2, "Expected the zero buffer threshold to flush multiple metrics tables"
+
+    df = pd.concat([t.to_pandas() for t in default_tables], ignore_index=True)
+    assert sorted(df["example_id"].tolist()) == [0, 1, 2, 3], "Rewritten tables should cover every image exactly once"
+
+    assert "embeddings_pca" in df.columns, "Expected the reduced image-embeddings column"
+    assert "embeddings" not in df.columns, "The raw image-embeddings column should have been rewritten"
+    for emb in df["embeddings_pca"]:
+        assert len(emb) == dim
+
+
+def test_metrics_flushing_segment_all_embeddings() -> None:
+    """The bug-report scenario: segmentation masks plus image, predicted and ground-truth instance embeddings,
+    with a zero buffer threshold. Every flushed table is rewritten with all three reduced columns while the
+    heavy mask column is carried through the rewrite."""
+    dim = 2
+    settings = Settings(
+        project_name="test_metrics_flushing_seg_all",
+        run_name="test_metrics_flushing_seg_all",
+        metrics_max_buffer_mb=0,  # flush after every batch
+        image_embeddings_dim=dim,
+        image_embeddings_reducer="pca",
+        instance_embeddings_dim=dim,
+        instance_embeddings_reducer="pca",
+        ground_truth_instance_embeddings=True,
+        label_column_name=TASK2LABEL_COLUMN_NAME["segment"],
+    )
+
+    model = TLCYOLO(TASK2MODEL["segment"])
+    model.collect(data=TASK2DATASET["segment"], splits=("train",), settings=settings, batch=2, device="cpu", workers=0)
+
+    run = _get_run_from_settings(settings)
+    default_tables = get_metrics_tables_from_run(run)["default_stream"]
+    assert len(default_tables) >= 2, "Expected the zero buffer threshold to flush multiple metrics tables"
+
+    df = pd.concat([t.to_pandas() for t in default_tables], ignore_index=True)
+    assert sorted(df["example_id"].tolist()) == [0, 1, 2, 3], "Rewritten tables should cover every image exactly once"
+
+    # The heavy mask column survived the rewrite alongside all three reduced embedding columns
+    assert "segmentations_predicted" in df.columns, "Expected the predicted segmentations column"
+    for column in ("embeddings_pca", "predicted_instance_embedding", "ground_truth_instance_embedding"):
+        assert column in df.columns, f"Expected reduced column '{column}'"
+    for raw_column in ("embeddings", "predicted_instance_embedding_raw", "ground_truth_instance_embedding_raw"):
+        assert raw_column not in df.columns, f"Raw column '{raw_column}' should have been rewritten"
+
+    for emb in df["embeddings_pca"]:
+        assert len(emb) == dim
+    for row_embs in df["predicted_instance_embedding"]:
+        for emb in row_embs:
+            assert len(emb) == dim
 
 
 def test_instance_embeddings_cross_split_shared_space() -> None:
@@ -3247,10 +3379,11 @@ def test_instance_embeddings_cross_split_shared_space() -> None:
             for emb in row_embs:
                 assert len(emb) == dim
 
-    # The run's reducer must not leak past collect()
+    # The run's reducers must not leak past collect()
     from tlc_ultralytics.utils._instance_reduce import _get_fitted_reducer
 
-    assert _get_fitted_reducer(run.url.to_str()) is None
+    assert _get_fitted_reducer(run.url.to_str(), "instance") is None
+    assert _get_fitted_reducer(run.url.to_str(), "image") is None
 
 
 def test_instance_embeddings_explicit_layer() -> None:

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -3258,6 +3258,8 @@ def test_metrics_flushing_with_instance_embeddings() -> None:
         metrics_max_buffer_mb=0,  # flush after every batch
         instance_embeddings_dim=dim,
         instance_embeddings_reducer="pca",
+        # A user-supplied n_components must be ignored in favor of instance_embeddings_dim
+        instance_embeddings_reducer_kwargs={"n_components": 7},
         instance_embeddings_fit_sample_size=5,  # force the sampled-fit path
         label_column_name=TASK2LABEL_COLUMN_NAME["detect"],
     )
@@ -3293,6 +3295,8 @@ def test_metrics_flushing_with_image_embeddings() -> None:
         metrics_max_buffer_mb=0,  # flush after every batch
         image_embeddings_dim=dim,
         image_embeddings_reducer="pca",
+        # A user-supplied n_components must be ignored in favor of image_embeddings_dim
+        image_embeddings_reducer_args={"n_components": 7},
         image_embeddings_fit_sample_size=3,  # force the sampled-fit path (fewer than the 4 images)
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,8 +12,8 @@ resolution-markers = [
 
 [[package]]
 name = "3lc"
-version = "3.0.2"
-source = { registry = "https://pypi.3lc.ai/public/repositories/releases-public" }
+version = "3.2"
+source = { editable = "../tlc-monorepo" }
 dependencies = [
     { name = "anyio" },
     { name = "boto3" },
@@ -54,29 +54,132 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-wheels = [
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp310-cp310-macosx_13_0_arm64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp310-cp310-manylinux_2_28_aarch64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp310-cp310-win_amd64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp311-cp311-macosx_13_0_arm64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp311-cp311-win_amd64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp312-cp312-macosx_13_0_arm64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp312-cp312-win_amd64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp313-cp313-macosx_13_0_arm64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://pypi.3lc.ai/public/repositories/releases-public/3lc/3lc-3.0.2-cp313-cp313-win_amd64.whl" },
-]
 
 [package.optional-dependencies]
 pandas = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "3lc", extras = ["torch"], marker = "extra == 'huggingface'" },
+    { name = "accelerate", marker = "extra == 'huggingface'", specifier = ">=1.2.1" },
+    { name = "adlfs", marker = "extra == 'abfs'", specifier = "==2024.4.1" },
+    { name = "annoy", marker = "extra == 'pacmap'", specifier = ">=1.17.0" },
+    { name = "anyio", specifier = ">=4.0.0" },
+    { name = "azure-storage-blob", marker = "extra == 'abfs'", specifier = ">=12.24.1" },
+    { name = "boto3", specifier = ">=1.36.23" },
+    { name = "cachetools", specifier = ">=5.5.0,<6.0.0" },
+    { name = "click", specifier = ">=8.0" },
+    { name = "cryptlex-lexactivator", specifier = ">=3.28.1,<4.0.0" },
+    { name = "datasets", marker = "extra == 'huggingface'", specifier = ">=2.17.0" },
+    { name = "evaluate", marker = "extra == 'huggingface'", specifier = ">=0.4.1,<1.0.0" },
+    { name = "filelock", specifier = ">=3.13.1,<4.0.0" },
+    { name = "fsspec", specifier = ">=2024.3.1" },
+    { name = "google-api-python-client", marker = "extra == 'gcs'", specifier = ">=2.194.0" },
+    { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=3.0.0" },
+    { name = "joblib", marker = "extra == 'pacmap'", specifier = ">=1.4.0,<2.0.0" },
+    { name = "joblib", marker = "extra == 'umap'", specifier = ">=1.4.0,<2.0.0" },
+    { name = "litestar", specifier = ">=2.21.1,<3.0.0" },
+    { name = "numba", marker = "extra == 'umap'", specifier = ">=0.61" },
+    { name = "numpy", specifier = ">=1.17.0,<3.0.0" },
+    { name = "opencv-python", specifier = ">=4.11.0.86" },
+    { name = "packaging", specifier = ">=23.1" },
+    { name = "pacmap", marker = "extra == 'pacmap'", specifier = ">=0.7.1,<0.9" },
+    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.4.2" },
+    { name = "pillow", specifier = ">=10.4.0,<13.0.0" },
+    { name = "platformdirs", specifier = ">=4.0.0,<5.0.0" },
+    { name = "psutil", specifier = ">=5.9.8,<6.0.0" },
+    { name = "pyarrow", specifier = ">=18" },
+    { name = "pycocotools", specifier = ">=2.0.10,<3.0.0" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyngrok", marker = "extra == 'pyngrok'", specifier = ">=7.1.3,<8.0.0" },
+    { name = "pyperclip", specifier = ">=1.11.0" },
+    { name = "python-dateutil", specifier = ">=2.9.0" },
+    { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=310,<311" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "randomname", specifier = ">=0.2.1,<1.0.0" },
+    { name = "requests", specifier = ">=2.33.0,<3.0.0" },
+    { name = "rich", specifier = ">=13.4.2,<14.0.0" },
+    { name = "ruamel-yaml", specifier = ">=0.17.32,<1.0.0" },
+    { name = "s3fs", specifier = ">=2024.3.1" },
+    { name = "scikit-learn", marker = "extra == 'pacmap'", specifier = ">=1.0.0" },
+    { name = "scikit-learn", marker = "extra == 'umap'", specifier = ">=1.0.0" },
+    { name = "sentry-sdk", extras = ["litestar"], specifier = ">=2.58.0,<3.0.0" },
+    { name = "termcolor", specifier = ">=2.2.0" },
+    { name = "textual", specifier = ">=0.52.1,<1.0.0" },
+    { name = "tomli", specifier = ">=2.0.1,<3.0.0" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'torch'", specifier = ">=1.8.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "(platform_machine != 'x86_64' and extra == 'torch') or (sys_platform != 'linux' and extra == 'torch')", specifier = ">=1.8.0" },
+    { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'torch'", specifier = ">=0.10.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", marker = "(platform_machine != 'x86_64' and extra == 'torch') or (sys_platform != 'linux' and extra == 'torch')", specifier = ">=0.10.0" },
+    { name = "tqdm", specifier = ">=4.65.0,<5.0.0" },
+    { name = "transformers", marker = "extra == 'huggingface'", specifier = ">=4.30.2,<5.0.0" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "umap-learn", marker = "extra == 'umap'", specifier = ">=0.5.4,<1.0.0" },
+    { name = "urllib3", specifier = ">=2.0.0" },
+    { name = "uvicorn", specifier = ">=0.17.6" },
+    { name = "watchdog", specifier = ">=4.0.0,<6.0.0" },
+]
+provides-extras = ["pandas", "torch", "huggingface", "gcs", "abfs", "umap", "pacmap", "pyngrok"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "3lc", extras = ["pandas"] },
+    { name = "3lcdev", editable = "../tlc-monorepo/src/tlcdev" },
+    { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "deptry", specifier = ">=0.25.1" },
+    { name = "httpx", specifier = "<1.0.0" },
+    { name = "importlib-metadata", specifier = ">=8.6.1" },
+    { name = "ipykernel", specifier = ">=6.21.2,<7.0.0" },
+    { name = "ipywidgets", specifier = ">=8.0.6,<9.0.0" },
+    { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
+    { name = "matplotlib", specifier = ">=3.7.1,<4.0.0" },
+    { name = "mypy", specifier = ">=2.0.0,<3.0.0" },
+    { name = "papermill", specifier = ">=2.5.0,<3.0.0" },
+    { name = "parquet-tools", specifier = ">=0.2.16" },
+    { name = "pre-commit", specifier = "==3.5.0" },
+    { name = "pyarmor", specifier = ">=9.0.7,<10.0.0" },
+    { name = "pyarrow-stubs", specifier = ">18" },
+    { name = "pylic", specifier = ">=5.0.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.23.8" },
+    { name = "pytest-benchmark", specifier = ">=4.0.0,<5.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0,<5.0.0" },
+    { name = "pytest-instafail", specifier = ">=0.5.0" },
+    { name = "pytest-mock", specifier = ">=3.11.1,<4.0.0" },
+    { name = "pytest-order", specifier = ">=1.3.0" },
+    { name = "pytest-repeat", specifier = ">=0.9.3,<1.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.3.1,<4.0.0" },
+    { name = "ruff", specifier = ">=0.15,<0.16" },
+    { name = "soundfile", specifier = ">=0.12.1" },
+    { name = "sphobjinv", specifier = ">=2.3.1.3" },
+    { name = "textual-dev", specifier = ">=1.5.1,<2.0.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.8,<7.0.0.0" },
+    { name = "types-requests", specifier = ">=2.33.0.0" },
+    { name = "types-tqdm", specifier = ">=4.65.0.1,<5.0.0.0" },
+]
+docs = [
+    { name = "furo", specifier = ">=2023.7.26,<2024.0.0" },
+    { name = "myst-parser", specifier = ">=2.0.0,<3.0.0" },
+    { name = "nbsphinx", specifier = ">=0.9.2,<1.0.0" },
+    { name = "sphinx", specifier = ">=7.2.6,<8.0.0" },
+    { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
+    { name = "sphinx-autodoc2", git = "https://github.com/3lc-ai/sphinx-autodoc2?rev=95138e48f1770ce84c0a4a4288020e595cc5a3c2" },
+    { name = "sphinx-click", specifier = ">=6.2.0" },
+    { name = "sphinx-codeautolink", specifier = ">=0.15.0,<0.17.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2,<1.0.0" },
+    { name = "sphinx-design", specifier = ">=0.6.0,<1.0.0" },
+    { name = "sphinx-docsearch", specifier = ">=0.0.4,<1.0.0" },
+    { name = "sphinx-inline-tabs", specifier = ">=2023.4.21" },
+    { name = "sphinx-reredirects", specifier = ">=0.1.6" },
+    { name = "sphinx-tippy", specifier = ">=0.4.1,<1.0.0" },
+    { name = "sphinx-togglebutton", specifier = ">=0.3.2,<1.0.0" },
+    { name = "sphinxcontrib-images", specifier = ">=0.9.4,<1.0.0" },
 ]
 
 [[package]]
@@ -101,14 +204,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "3lc", specifier = ">=3.0.0,<4.0.0" },
+    { name = "3lc", editable = "../tlc-monorepo" },
     { name = "pacmap", specifier = ">=0.8.0,<0.9" },
     { name = "ultralytics", specifier = ">=8.4.0,<8.4.67" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "3lc", extras = ["pandas"], specifier = ">=3.0.0,<4.0.0" },
+    { name = "3lc", extras = ["pandas"], editable = "../tlc-monorepo" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },


### PR DESCRIPTION
- Bound memory usage by metrics by flushing metrics tables more often, not just at the end of each pass
- Fit embeddings reducers on a subset of the data
- Transform embeddings in batches