### PR TITLE
Don't carry the tlc.Table into dataloader workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 - `collect_loss=True` now warns and is disabled for the `segment` and `obb` tasks instead of being silently ignored, and loss schemas are no longer declared when loss collection is disabled.
 
-- Datasets no longer carry the `tlc.Table` into dataloader workers. This applies wherever the dataset is pickled into worker processes - the `spawn`/`forkserver` start methods, which are the default on macOS and Windows - and previously copied the full annotations of both the train and val tables into every worker, even though workers never read them. The Table is now replaced by its URL before pickling and restored lazily if anything asks for it, so `dataset.table` keeps working everywhere it is used.
+- No longer carry full `tlc.Table`s into dataloader workers. The `tlc.Table` backing a dataset is always available through the now lazy attribute `dataset.table`.
 
 ## [0.4.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 - `collect_loss=True` now warns and is disabled for the `segment` and `obb` tasks instead of being silently ignored, and loss schemas are no longer declared when loss collection is disabled.
 
-- Datasets no longer carry the `tlc.Table` into dataloader workers. A Table keeps all of its row data resident in memory, and where workers are spawned rather than forked (macOS and Windows) each worker received a full copy of the annotations of both the train and the val table - memory nothing in the worker reads, since labels are built once at dataset construction. The Table is now replaced by its URL when the dataset is pickled, and restored lazily if anything asks for it, so `dataset.table` keeps working everywhere it is used.
+- Datasets no longer carry the `tlc.Table` into dataloader workers. This applies wherever the dataset is pickled into worker processes - the `spawn`/`forkserver` start methods, which are the default on macOS and Windows - and previously copied the full annotations of both the train and val tables into every worker, even though workers never read them. The Table is now replaced by its URL before pickling and restored lazily if anything asks for it, so `dataset.table` keeps working everywhere it is used.
 
 ## [0.4.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 - `collect_loss=True` now warns and is disabled for the `segment` and `obb` tasks instead of being silently ignored, and loss schemas are no longer declared when loss collection is disabled.
 
+- Datasets no longer carry the `tlc.Table` into dataloader workers. A Table keeps all of its row data resident in memory, and where workers are spawned rather than forked (macOS and Windows) each worker received a full copy of the annotations of both the train and the val table - memory nothing in the worker reads, since labels are built once at dataset construction. The Table is now replaced by its URL when the dataset is pickled, and restored lazily if anything asks for it, so `dataset.table` keeps working everywhere it is used.
+
 ## [0.4.0] - 2026-08-07
 
 ### Added

--- a/src/tlc_ultralytics/classify/dataset.py
+++ b/src/tlc_ultralytics/classify/dataset.py
@@ -13,7 +13,10 @@ from tlc_ultralytics.utils.dataset import map_label
 
 class _DummyImageFolder:
     def __init__(self, root: tlc.Table, allow_empty: bool = False, samples: list[tuple[str, int]] | None = None):
-        self._root = root
+        # Only the Table's URL is ever needed here, and `ClassificationDataset` keeps this object alive for the
+        # lifetime of the dataset - store the URL rather than the Table so the Table's resident row data is not
+        # pickled to every dataloader worker. See `TLCDatasetMixin.__getstate__`.
+        self._root_url = root.url
         self._samples = samples
 
     @property
@@ -22,7 +25,7 @@ class _DummyImageFolder:
 
     @property
     def root(self):
-        return self._root.url
+        return self._root_url
 
     @property
     def classes(self):

--- a/src/tlc_ultralytics/classify/dataset.py
+++ b/src/tlc_ultralytics/classify/dataset.py
@@ -13,9 +13,7 @@ from tlc_ultralytics.utils.dataset import map_label
 
 class _DummyImageFolder:
     def __init__(self, root: tlc.Table, allow_empty: bool = False, samples: list[tuple[str, int]] | None = None):
-        # Only the Table's URL is ever needed here, and `ClassificationDataset` keeps this object alive for the
-        # lifetime of the dataset - store the URL rather than the Table so the Table's resident row data is not
-        # pickled to every dataloader worker. See `TLCDatasetMixin.__getstate__`.
+        # Store the URL, not the Table, so the Table's row data is not pickled into dataloader workers.
         self._root_url = root.url
         self._samples = samples
 

--- a/src/tlc_ultralytics/detect/dataset.py
+++ b/src/tlc_ultralytics/detect/dataset.py
@@ -295,8 +295,8 @@ class TLCYOLOSegmentationDataset(BaseTLCYOLODataset):
         """
         column_name, _, _ = self._label_column_name.split(".")
 
-        # The row view holds the raw, serialized segmentation dict.
-        row = self.table.table_rows[example_id]
+        # `row` is already the row view holding the raw, serialized segmentation dict - re-reading it from the
+        # Table would decode the same row a second time.
         raw_segmentations = row[column_name]
 
         # Masks are RLE-encoded and the size is reconstructed solely from the stored dimensions,

--- a/src/tlc_ultralytics/detect/dataset.py
+++ b/src/tlc_ultralytics/detect/dataset.py
@@ -295,8 +295,7 @@ class TLCYOLOSegmentationDataset(BaseTLCYOLODataset):
         """
         column_name, _, _ = self._label_column_name.split(".")
 
-        # `row` is already the row view holding the raw, serialized segmentation dict - re-reading it from the
-        # Table would decode the same row a second time.
+        # The row view holds the raw, serialized segmentation dict.
         raw_segmentations = row[column_name]
 
         # Masks are RLE-encoded and the size is reconstructed solely from the stored dimensions,

--- a/src/tlc_ultralytics/engine/dataset.py
+++ b/src/tlc_ultralytics/engine/dataset.py
@@ -45,19 +45,12 @@ class TLCDatasetMixin:
         self._table_url = table.url if isinstance(table, tlc.Table) else None
 
     def __getstate__(self) -> dict[str, Any]:
-        """Drop every reference to the `tlc.Table` from the state pickled to dataloader workers.
+        """Replace every reference to the `tlc.Table` with its `tlc.Url` before pickling to a dataloader worker.
 
-        Workers only ever read `self.labels` and `self.im_files` - the per-item path never touches the Table, which
-        is fully consumed at construction time by `_get_rows_from_table`. A Table however holds all of its row data
-        resident as a `pyarrow.Table`, and `tlc.Table.__getstate__` pickles that data as-is, so any surviving
-        reference ships the entire dataset's annotations to every worker. On platforms where dataloader workers are
-        spawned rather than forked (macOS, Windows, and `spawn` start methods generally) that is `workers` extra
-        copies of data nothing reads. All references have to go, not just `self.table`: pickle memoizes, so a single
-        surviving one costs the full Table.
-
-        The references are `self.table`, `self.img_path` (Ultralytics stores the first constructor argument, which
-        is the Table for our datasets) and the `train`/`val` entries of `self.data`. Each is replaced by the
-        corresponding `tlc.Url`; `self.table` is restored lazily from that URL should anything ask for it.
+        A Table keeps all of its row data resident in memory, and workers never read it - labels are built once at
+        construction. This only takes effect when the dataset is actually pickled, i.e. under `spawn`/`forkserver`
+        dataloader worker start methods (the default on macOS and Windows); under `fork`, workers inherit memory
+        without pickling and this method never runs.
 
         :return: The dataset state to pickle, with Tables replaced by their URLs.
         """
@@ -65,7 +58,7 @@ class TLCDatasetMixin:
         state["_table"] = None
 
         if isinstance(state.get("img_path"), tlc.Table) and self._table_url is not None:
-            state["img_path"] = self._table_url.to_str()
+            state["img_path"] = self._table_url
 
         data = state.get("data")
         if isinstance(data, dict):

--- a/src/tlc_ultralytics/engine/dataset.py
+++ b/src/tlc_ultralytics/engine/dataset.py
@@ -19,12 +19,64 @@ if TYPE_CHECKING:
 class TLCDatasetMixin:
     _warned_missing_image_dimensions = False
 
-    def _post_init(self):
-        self.display_name = self.table.dataset_name
+    # Backing state for the `table` property. Class-level defaults so `hasattr(self, "table")` is answerable
+    # before any subclass has assigned a Table.
+    _table: tlc.Table | None = None
+    _table_url: tlc.Url | None = None
 
-        assert hasattr(self, "table") and isinstance(self.table, tlc.Table), (
-            "TLCDatasetMixin requires an attribute `table` which is a tlc.Table."
-        )
+    @property
+    def table(self) -> tlc.Table:
+        """The `tlc.Table` backing this dataset, restored from its URL if it was dropped when the dataset was
+        pickled to a dataloader worker. See `__getstate__` for why the Table does not cross that boundary.
+
+        :return: The Table this dataset was built from.
+        :raises AttributeError: If no Table has been assigned to this dataset.
+        """
+        if self._table is None:
+            if self._table_url is None:
+                msg = "TLCDatasetMixin requires an attribute `table` which is a tlc.Table."
+                raise AttributeError(msg)
+            self._table = tlc.Table.from_url(self._table_url)
+        return self._table
+
+    @table.setter
+    def table(self, table: tlc.Table) -> None:
+        self._table = table
+        self._table_url = table.url if isinstance(table, tlc.Table) else None
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Drop every reference to the `tlc.Table` from the state pickled to dataloader workers.
+
+        Workers only ever read `self.labels` and `self.im_files` - the per-item path never touches the Table, which
+        is fully consumed at construction time by `_get_rows_from_table`. A Table however holds all of its row data
+        resident as a `pyarrow.Table`, and `tlc.Table.__getstate__` pickles that data as-is, so any surviving
+        reference ships the entire dataset's annotations to every worker. On platforms where dataloader workers are
+        spawned rather than forked (macOS, Windows, and `spawn` start methods generally) that is `workers` extra
+        copies of data nothing reads. All references have to go, not just `self.table`: pickle memoizes, so a single
+        surviving one costs the full Table.
+
+        The references are `self.table`, `self.img_path` (Ultralytics stores the first constructor argument, which
+        is the Table for our datasets) and the `train`/`val` entries of `self.data`. Each is replaced by the
+        corresponding `tlc.Url`; `self.table` is restored lazily from that URL should anything ask for it.
+
+        :return: The dataset state to pickle, with Tables replaced by their URLs.
+        """
+        state = self.__dict__.copy()
+        state["_table"] = None
+
+        if isinstance(state.get("img_path"), tlc.Table) and self._table_url is not None:
+            state["img_path"] = self._table_url.to_str()
+
+        data = state.get("data")
+        if isinstance(data, dict):
+            state["data"] = {key: value.url if isinstance(value, tlc.Table) else value for key, value in data.items()}
+
+        return state
+
+    def _post_init(self):
+        assert isinstance(self._table, tlc.Table), "TLCDatasetMixin requires an attribute `table` which is a tlc.Table."
+
+        self.display_name = self.table.dataset_name
 
         if len(self.table) == 0:
             msg = f"The Table with URL {self.table.url.to_str()} has no rows, provide a Table populated with data."
@@ -228,7 +280,9 @@ class TLCDatasetMixin:
         :yield: Valid example IDs
         """
         corrupt_set = set(corrupt_example_ids)
-        weight_column_name = self.table.weights_column_name
+
+        # A table without a weights column has no zero-weight rows to exclude.
+        weight_column_name = self.table.weights_column_name if self._exclude_zero else None
 
         excluded_count = 0
 
@@ -238,7 +292,7 @@ class TLCDatasetMixin:
                 continue
 
             # Skip zero-weight images if exclusion is enabled
-            if self._exclude_zero and self.table.table_rows[example_id].get(weight_column_name, 1) == 0:
+            if weight_column_name is not None and self.table.table_rows[example_id].get(weight_column_name, 1) == 0:
                 excluded_count += 1
                 continue
 

--- a/src/tlc_ultralytics/engine/dataset.py
+++ b/src/tlc_ultralytics/engine/dataset.py
@@ -19,19 +19,12 @@ if TYPE_CHECKING:
 class TLCDatasetMixin:
     _warned_missing_image_dimensions = False
 
-    # Backing state for the `table` property. Class-level defaults so `hasattr(self, "table")` is answerable
-    # before any subclass has assigned a Table.
     _table: tlc.Table | None = None
     _table_url: tlc.Url | None = None
 
     @property
     def table(self) -> tlc.Table:
-        """The `tlc.Table` backing this dataset, restored from its URL if it was dropped when the dataset was
-        pickled to a dataloader worker. See `__getstate__` for why the Table does not cross that boundary.
-
-        :return: The Table this dataset was built from.
-        :raises AttributeError: If no Table has been assigned to this dataset.
-        """
+        """The `tlc.Table` backing this dataset, restored lazily from its URL after unpickling in a worker."""
         if self._table is None:
             if self._table_url is None:
                 msg = "TLCDatasetMixin requires an attribute `table` which is a tlc.Table."
@@ -45,14 +38,10 @@ class TLCDatasetMixin:
         self._table_url = table.url if isinstance(table, tlc.Table) else None
 
     def __getstate__(self) -> dict[str, Any]:
-        """Replace every reference to the `tlc.Table` with its `tlc.Url` before pickling to a dataloader worker.
+        """Replace Table references with their URLs when pickling to a dataloader worker.
 
         A Table keeps all of its row data resident in memory, and workers never read it - labels are built once at
-        construction. This only takes effect when the dataset is actually pickled, i.e. under `spawn`/`forkserver`
-        dataloader worker start methods (the default on macOS and Windows); under `fork`, workers inherit memory
-        without pickling and this method never runs.
-
-        :return: The dataset state to pickle, with Tables replaced by their URLs.
+        construction. Applies under the `spawn`/`forkserver` worker start methods; `fork` never pickles the dataset.
         """
         state = self.__dict__.copy()
         state["_table"] = None
@@ -273,8 +262,6 @@ class TLCDatasetMixin:
         :yield: Valid example IDs
         """
         corrupt_set = set(corrupt_example_ids)
-
-        # A table without a weights column has no zero-weight rows to exclude.
         weight_column_name = self.table.weights_column_name if self._exclude_zero else None
 
         excluded_count = 0

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -2404,7 +2404,7 @@ def test_dataset_cache(task) -> None:
     assert cache_data["corrupt_example_ids"] == []
 
 
-@pytest.mark.parametrize("task", ["detect", "segment", "classify"])
+@pytest.mark.parametrize("task", ["detect", "segment", "classify", "obb", "pose"])
 def test_dataset_does_not_pickle_table(task: str) -> None:
     """No `tlc.Table` may cross the pickle boundary into a dataloader worker.
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import io
 import json
 import logging
 import os
 import pathlib
+import pickle
 import random
 import sys
 from collections import defaultdict
@@ -2400,6 +2402,55 @@ def test_dataset_cache(task) -> None:
     cache_data = json.loads(cache_path.read_text())
     assert cache_data["version"] == 1, "Cache version should be 1"
     assert cache_data["corrupt_example_ids"] == []
+
+
+@pytest.mark.parametrize("task", ["detect", "segment", "classify"])
+def test_dataset_does_not_pickle_table(task: str) -> None:
+    """No `tlc.Table` may cross the pickle boundary into a dataloader worker.
+
+    Tables hold all of their row data resident, so a single surviving reference costs one full copy of the
+    annotations per worker on `spawn` platforms. The worker only reads `labels`/`im_files`, and the Table is
+    restored lazily from its URL if anything does ask for it.
+    """
+    settings = Settings(project_name=f"test_dataset_pickle_{task}")
+    trainer = TASK2TRAINER[task](
+        overrides={"data": TASK2DATASET[task], "model": TASK2MODEL[task], "settings": settings},
+    )
+    trainer.model = stub_model_with_stride()
+
+    table = trainer.data["train"]
+    dataset = trainer.build_dataset(table, mode="val", batch=1)
+
+    # `reducer_override` runs for every object the pickler actually writes, so this catches a Table reached by
+    # any path, however indirect.
+    pickled_tables: list[tlc.Table] = []
+
+    class TableDetectingPickler(pickle.Pickler):
+        def reducer_override(self, obj):
+            if isinstance(obj, tlc.Table):
+                pickled_tables.append(obj)
+            return NotImplemented
+
+    buffer = io.BytesIO()
+    TableDetectingPickler(buffer).dump(dataset)
+    assert not pickled_tables, f"Tables written into the worker payload: {[t.url.to_str() for t in pickled_tables]}"
+
+    # The main process is unaffected: the Table is still there and the shared data dict is not mutated
+    assert dataset.table is table, "The dataset should still hold the Table it was built from"
+    assert dataset.display_name == table.dataset_name, "display_name should survive"
+    assert dataset.table.url == table.url, "The validator reads dataset.table.url"
+    assert trainer.data["train"] is table, "__getstate__ must not mutate the shared data dict"
+
+    # A worker can produce samples without ever materializing the Table
+    worker_dataset = pickle.loads(buffer.getvalue())
+    assert worker_dataset.__dict__["_table"] is None, "The unpickled dataset should not carry a Table"
+    assert len(worker_dataset) == len(dataset), "The unpickled dataset should have the same length"
+    sample = worker_dataset[0]
+    assert "example_id" in sample, "The unpickled dataset should still produce example ids"
+    assert worker_dataset.__dict__["_table"] is None, "__getitem__ must not reload the Table"
+
+    # ...but it is restored on demand if anything asks for it
+    assert worker_dataset.table.url == table.url, "The Table should be restored lazily from its URL"
 
 
 def test_bad_arguments() -> None:

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -2406,11 +2406,8 @@ def test_dataset_cache(task) -> None:
 
 @pytest.mark.parametrize("task", ["detect", "segment", "classify", "obb", "pose"])
 def test_dataset_does_not_pickle_table(task: str) -> None:
-    """No `tlc.Table` may cross the pickle boundary into a dataloader worker.
-
-    Tables hold all of their row data resident, so a single surviving reference costs one full copy of the
-    annotations per worker on `spawn` platforms. The worker only reads `labels`/`im_files`, and the Table is
-    restored lazily from its URL if anything does ask for it.
+    """No `tlc.Table` may cross the pickle boundary into a dataloader worker - a single surviving reference costs
+    one full copy of the annotations per worker on `spawn` platforms.
     """
     settings = Settings(project_name=f"test_dataset_pickle_{task}")
     trainer = TASK2TRAINER[task](
@@ -2421,8 +2418,7 @@ def test_dataset_does_not_pickle_table(task: str) -> None:
     table = trainer.data["train"]
     dataset = trainer.build_dataset(table, mode="val", batch=1)
 
-    # `reducer_override` runs for every object the pickler actually writes, so this catches a Table reached by
-    # any path, however indirect.
+    # `reducer_override` sees every object the pickler writes, so this catches a Table reached by any path.
     pickled_tables: list[tlc.Table] = []
 
     class TableDetectingPickler(pickle.Pickler):


### PR DESCRIPTION
A tlc.Table keeps all of its row data resident as a pyarrow.Table, and Table.__getstate__ pickles that data as-is. Our datasets held four references to Tables - self.table, self.img_path (Ultralytics stores the first constructor argument, which is the Table for us), and the train and val entries of self.data - so where the dataset is pickled into worker processes, every dataloader worker received a full copy of the annotations of both tables. Workers never read any of it: labels are built once at construction by _get_rows_from_table and the per-item path only touches self.labels and self.im_files.

This removes the Table from the pickled worker state, which matters on the `spawn`/`forkserver` dataloader worker start methods (the default on macOS and Windows, and available on Linux). Under Linux's default `fork` start method, workers inherit the parent's memory copy-on-write and the dataset is never pickled, so this change is not exercised there - dropping the reference in the parent process can still help marginally against GC-driven copy-on-write page breaks, but it is not a fix for the fork case.

Replace each reference with the corresponding tlc.Url when the dataset is pickled, and make `table` a property that restores the Table lazily from its URL, so dataset.table and dataset.display_name keep working for the validator. The classification dataset's _DummyImageFolder shim only ever needed the URL, so it now stores that instead of the Table.

Also drop a redundant re-read of the row in the segmentation label builder, and narrow the weights column lookup in _filter_example_ids to short-circuit when a table has no weights column, avoiding an unnecessary lookup (`dict.get(None, 1)` was already safe, so this is a micro-optimization, not a bug fix).
