### PR TITLE
Gate per-class metrics collection on collection enabled/disabled, clear from caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Since this package integrates with two actively developed dependencies (`ultraly
 
 - The supported `3lc` range is now `>=3.2.0,<4.0.0` (up from `>=3.0.0`). `3lc` 3.0 and 3.1 were only ever published to 3LC's public package index and are not available on PyPI, so they are no longer supported.
 
+### Fixed
+
+- Only write per-class metrics tables when metrics collection is active, instead of unconditionally on every validation pass. Previously these tables were written even on non-collection training epochs and when `collection_disable` was set, needlessly growing the run's metrics list and leaking table objects in the object registry cache.
+
 ## [0.4.0] - 2026-08-07
 
 ### Added

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -207,8 +207,6 @@ class TLCValidatorMixin(BaseValidator):
             ultralytics.engine.validator.check_cls_dataset = ultralytics.data.utils.check_cls_dataset
 
         # Per-class metrics only on RANK 0 (uses aggregate metrics from gather_stats).
-        # _write_per_class_metrics_tables is itself gated on self._should_collect, so it's a
-        # no-op on non-collection epochs and when collection is disabled.
         if RANK in {-1, 0}:
             self._write_per_class_metrics_tables()
 

--- a/src/tlc_ultralytics/engine/validator.py
+++ b/src/tlc_ultralytics/engine/validator.py
@@ -206,7 +206,9 @@ class TLCValidatorMixin(BaseValidator):
             ultralytics.engine.validator.check_det_dataset = ultralytics.data.utils.check_det_dataset
             ultralytics.engine.validator.check_cls_dataset = ultralytics.data.utils.check_cls_dataset
 
-        # Per-class metrics only on RANK 0 (uses aggregate metrics from gather_stats)
+        # Per-class metrics only on RANK 0 (uses aggregate metrics from gather_stats).
+        # _write_per_class_metrics_tables is itself gated on self._should_collect, so it's a
+        # no-op on non-collection epochs and when collection is disabled.
         if RANK in {-1, 0}:
             self._write_per_class_metrics_tables()
 
@@ -1163,6 +1165,7 @@ class TLCValidatorMixin(BaseValidator):
         except Exception as exc:
             LOGGER.warning(f"{TLC_COLORSTR}Failed to delete intermediate raw metrics table at {table_url}: {exc}")
 
+    @execute_when_collecting
     def _write_per_class_metrics_tables(self) -> None:
         if self.args.task not in ("detect", "segment", "obb"):
             # Per-class metrics currently only supported for detection, segmentation, and obb tasks
@@ -1198,7 +1201,10 @@ class TLCValidatorMixin(BaseValidator):
         )
 
         metrics_writer.add_batch(metrics_batch)
-        metrics_writer.finalize()
+        table = metrics_writer.finalize()
+
+        # Improve memory usage - don't cache the written table
+        ObjectRegistry._delete_object_from_caches(table.url)
 
     def _per_class_metrics_schemas(self):
         metrics_schemas = {

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -668,7 +668,7 @@ def test_train_collection_val_only() -> None:
     assert len(run.metrics_tables) == 1, "Expected only validation metrics to be collected after training"
 
 
-@pytest.mark.parametrize("task", ["classify", "detect"])
+@pytest.mark.parametrize("task", ["classify", "detect", "segment", "obb"])
 def test_train_collection_disabled(task: str) -> None:
     model_arg = TASK2MODEL[task]
     overrides = {"data": TASK2DATASET[task], "device": "cpu", "epochs": 1, "batch": 4, "imgsz": 224}
@@ -682,9 +682,7 @@ def test_train_collection_disabled(task: str) -> None:
     )
     model.train(**overrides, settings=settings)
 
-    # Ensure that no metrics tables are written, including per-class ones. Detection/segmentation/obb tasks
-    # write a per-class metrics table per validation pass unless that write is itself gated on collection
-    # being enabled, so this also covers the case classify can't (it never writes per-class tables).
+    # classify never writes per-class tables, so only detect/segment/obb can catch a gating regression here.
     run = _get_run_from_settings(settings)
     assert len(run.metrics_tables) == 0, "Expected no metrics tables to be written"
 

--- a/tests/test_tlc_ultralytics.py
+++ b/tests/test_tlc_ultralytics.py
@@ -668,8 +668,8 @@ def test_train_collection_val_only() -> None:
     assert len(run.metrics_tables) == 1, "Expected only validation metrics to be collected after training"
 
 
-def test_train_collection_disabled() -> None:
-    task = "classify"
+@pytest.mark.parametrize("task", ["classify", "detect"])
+def test_train_collection_disabled(task: str) -> None:
     model_arg = TASK2MODEL[task]
     overrides = {"data": TASK2DATASET[task], "device": "cpu", "epochs": 1, "batch": 4, "imgsz": 224}
 
@@ -677,12 +677,14 @@ def test_train_collection_disabled() -> None:
 
     settings = Settings(
         collection_disable=True,
-        project_name="test_train_collection_disabled",
-        run_name="test_train_collection_disabled",
+        project_name=f"test_train_collection_disabled_{task}",
+        run_name=f"test_train_collection_disabled_{task}",
     )
     model.train(**overrides, settings=settings)
 
-    # Ensure that only validation metrics are collected after training
+    # Ensure that no metrics tables are written, including per-class ones. Detection/segmentation/obb tasks
+    # write a per-class metrics table per validation pass unless that write is itself gated on collection
+    # being enabled, so this also covers the case classify can't (it never writes per-class tables).
     run = _get_run_from_settings(settings)
     assert len(run.metrics_tables) == 0, "Expected no metrics tables to be written"
 


### PR DESCRIPTION
_write_per_class_metrics_tables ran unconditionally on every validation pass, including non-collection training epochs and when collection_disable=True. Each call wrote a small metrics table, deepcopied the run's growing metrics list via Run.update_metrics, and left the written Table registered in tlc's process-global ObjectRegistry cache forever (the eviction calls elsewhere in this file only covered the collection-path tables).

Decorate the method with the existing execute_when_collecting so it's a no-op when self._should_collect is False, and evict the finalized table's url from the object caches the same way _RollingMetricsWriter does after its own finalize().

Extend test_train_collection_disabled to also cover a detect task (in addition to classify), since only detect/segment/obb write per-class tables and the classify case alone couldn't have caught this.